### PR TITLE
fix: ATOMIC_USIZE_INIT -> AtomicUsize::new(0)

### DIFF
--- a/src/device/dev_lock.rs
+++ b/src/device/dev_lock.rs
@@ -3,7 +3,7 @@
 
 use std::cell::UnsafeCell;
 use std::ops::{Deref, DerefMut};
-use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 /// A special type of read/write lock, that makes the following assumptions:
 /// a) Read access is frequent, and has to be very fast
@@ -42,7 +42,7 @@ impl<T> Lock<T> {
     /// New lock
     pub const fn new(user_data: T) -> Lock<T> {
         Lock {
-            lock: ATOMIC_USIZE_INIT,
+            lock: AtomicUsize::new(0),
             data: UnsafeCell::new(user_data),
         }
     }


### PR DESCRIPTION
```
warning: use of deprecated item 'std::sync::atomic::ATOMIC_USIZE_INIT': the `new` function is now preferred
 --> src/device/dev_lock.rs:6:48
  |
6 | use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
  |                                                ^^^^^^^^^^^^^^^^^
  |
  = note: #[warn(deprecated)] on by default

warning: use of deprecated item 'std::sync::atomic::ATOMIC_USIZE_INIT': the `new` function is now preferred
  --> src/device/dev_lock.rs:45:19
   |
45 |             lock: ATOMIC_USIZE_INIT,
   |                   ^^^^^^^^^^^^^^^^^
help: use of deprecated item 'std::sync::atomic::ATOMIC_USIZE_INIT': the `new` function is now preferred
   |
45 |             lock: AtomicUsize::new(0),
   |                   ^^^^^^^^^^^^^^^^^^^
```