### PR TITLE
change SIOCGIFMTU type to i32 (musl ioctl)

### DIFF
--- a/src/device/tun_linux.rs
+++ b/src/device/tun_linux.rs
@@ -45,6 +45,9 @@ pub struct ifreq {
     ifr_ifru: IfrIfru,
 }
 
+#[cfg(target_env = "musl")]
+const SIOCGIFMTU: int32_t = 0x8921;
+
 #[derive(Default, Debug)]
 pub struct TunSocket {
     fd: RawFd,


### PR DESCRIPTION
ioctl function signature differs on glibc and musl libc.
extern int ioctl (int __fd, unsigned long int __request, ...) __THROW;
vs.
int ioctl (int, int, ...);

To avoid mismatched types errors on musl I shamelessly copied tun_darwin.rs' definition of SIOCGIFMTU.