### PR TITLE
Fix musl build by letting Rust infer the correct type for SIOCGIFMTU

### DIFF
--- a/src/device/tun_linux.rs
+++ b/src/device/tun_linux.rs
@@ -122,7 +122,7 @@ impl TunSocket {
 
         ifr.ifr_name[..iface_name.len()].copy_from_slice(iface_name);
 
-        if unsafe { ioctl(fd, SIOCGIFMTU, &ifr) } < 0 {
+        if unsafe { ioctl(fd, SIOCGIFMTU as _, &ifr) } < 0 {
             return Err(Error::IOCtl(errno_str()));
         }
 


### PR DESCRIPTION
Fixes #47 