### PR TITLE
Fix typo in command-line arg

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -144,7 +144,7 @@ fn main() {
         }
     };
 
-    if !matches.is_present("disable-drop-priviliges") {
+    if !matches.is_present("disable-drop-privileges") {
         drop_privileges().ok();
     }
 


### PR DESCRIPTION
Change "disable-drop-priviliges" to correct spelling as used elsewhere in the file.