### PR TITLE
Open existing log files if they exist

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -100,10 +100,16 @@ fn main() {
         let log = matches.value_of("log").unwrap();
         let err_log = matches.value_of("err").unwrap();
 
-        let stdout =
-            File::create(&log).unwrap_or_else(|_| panic!("Could not create log file {}", log));
-        let stderr = File::create(&err_log)
-            .unwrap_or_else(|_| panic!("Could not create error log file {}", err_log));
+        let stdout = match File::open(&log) {
+            Ok(fd) => fd,
+            Err(_) => File::create(&log).unwrap_or_else(|_| panic!("Could not create log file {}", log)),
+        };
+
+        let stderr = match File::open(&log) {
+            Ok(fd) => fd,
+            Err(_) => File::create(&err_log)
+                .unwrap_or_else(|_| panic!("Could not create error log file {}", err_log)),
+        };
 
         let daemonize = Daemonize::new()
             .working_directory("/tmp")

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,7 +105,7 @@ fn main() {
             Err(_) => File::create(&log).unwrap_or_else(|_| panic!("Could not create log file {}", log)),
         };
 
-        let stderr = match File::open(&log) {
+        let stderr = match File::open(&err_log) {
             Ok(fd) => fd,
             Err(_) => File::create(&err_log)
                 .unwrap_or_else(|_| panic!("Could not create error log file {}", err_log)),

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,7 +102,9 @@ fn main() {
 
         let stdout = match File::open(&log) {
             Ok(fd) => fd,
-            Err(_) => File::create(&log).unwrap_or_else(|_| panic!("Could not create log file {}", log)),
+            Err(_) => {
+                File::create(&log).unwrap_or_else(|_| panic!("Could not create log file {}", log))
+            }
         };
 
         let stderr = match File::open(&err_log) {


### PR DESCRIPTION
# Problem

If log files `/tmp/boringtun.out` or `/tmp/boringtun.err` are preexisting, a panic occurs:

```
$ cargo run wg0
    Finished dev [unoptimized + debuginfo] target(s) in 0.04s
     Running `sudo -E target/debug/boringtun wg0`
thread 'main' panicked at 'Could not create log file /tmp/boringtun.out', src/main.rs:104:51
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
$ rm /tmp/boringtun.out
$ cargo run wg0
    Finished dev [unoptimized + debuginfo] target(s) in 0.04s
     Running `sudo -E target/debug/boringtun wg0`
thread 'main' panicked at 'Could not create error log file /tmp/boringtun.err', src/main.rs:106:33
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
```

# Solution

Log files are opened before attempting to create them. If opening fails, creation is attempted. If creation subsequently fails, a panic will still occur.