### PR TITLE
Make device mod public

### DIFF
--- a/src/device/api.rs
+++ b/src/device/api.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 use super::{make_array, AllowedIP, Device, Error, SocketAddr, X25519PublicKey, X25519SecretKey};
-use crate::dev_lock::LockReadGuard;
+use crate::device::dev_lock::LockReadGuard;
 use crate::device::drop_privileges::*;
 use crate::device::Action;
 use hex::encode as encode_hex;

--- a/src/device/api.rs
+++ b/src/device/api.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 use super::{make_array, AllowedIP, Device, Error, SocketAddr, X25519PublicKey, X25519SecretKey};
-use crate::device::dev_lock::LockReadGuard;
-use crate::device::drop_privileges::*;
+use super::dev_lock::LockReadGuard;
+use super::drop_privileges::*;
 use crate::device::Action;
 use hex::encode as encode_hex;
 use libc::*;

--- a/src/device/api.rs
+++ b/src/device/api.rs
@@ -1,9 +1,9 @@
 // Copyright (c) 2019 Cloudflare, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
-use super::{make_array, AllowedIP, Device, Error, SocketAddr, X25519PublicKey, X25519SecretKey};
 use super::dev_lock::LockReadGuard;
 use super::drop_privileges::*;
+use super::{make_array, AllowedIP, Device, Error, SocketAddr, X25519PublicKey, X25519SecretKey};
 use crate::device::Action;
 use hex::encode as encode_hex;
 use libc::*;

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -38,17 +38,17 @@ use std::sync::Arc;
 use std::thread;
 use std::thread::JoinHandle;
 
-use crate::allowed_ips::*;
+use crate::device::allowed_ips::*;
 use crate::crypto::x25519::*;
-use crate::dev_lock::*;
+use crate::device::dev_lock::*;
 use crate::noise::errors::*;
 use crate::noise::handshake::parse_handshake_anon;
 use crate::noise::rate_limiter::RateLimiter;
 use crate::noise::*;
-use crate::peer::*;
-use crate::poll::*;
-use crate::tun::*;
-use crate::udp::*;
+use crate::device::peer::*;
+use crate::device::poll::*;
+use crate::device::tun::*;
+use crate::device::udp::*;
 
 const HANDSHAKE_RATE_LIMIT: u64 = 100; // The number of handshakes per second we can tolerate before using cookies
 

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -38,13 +38,13 @@ use std::sync::Arc;
 use std::thread;
 use std::thread::JoinHandle;
 
-use allowed_ips::*;
 use crate::crypto::x25519::*;
-use dev_lock::*;
 use crate::noise::errors::*;
 use crate::noise::handshake::parse_handshake_anon;
 use crate::noise::rate_limiter::RateLimiter;
 use crate::noise::*;
+use allowed_ips::*;
+use dev_lock::*;
 use peer::*;
 use poll::*;
 use tun::*;

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -38,17 +38,17 @@ use std::sync::Arc;
 use std::thread;
 use std::thread::JoinHandle;
 
-use crate::device::allowed_ips::*;
+use allowed_ips::*;
 use crate::crypto::x25519::*;
-use crate::device::dev_lock::*;
+use dev_lock::*;
 use crate::noise::errors::*;
 use crate::noise::handshake::parse_handshake_anon;
 use crate::noise::rate_limiter::RateLimiter;
 use crate::noise::*;
-use crate::device::peer::*;
-use crate::device::poll::*;
-use crate::device::tun::*;
-use crate::device::udp::*;
+use peer::*;
+use poll::*;
+use tun::*;
+use udp::*;
 
 const HANDSHAKE_RATE_LIMIT: u64 = 100; // The number of handshakes per second we can tolerate before using cookies
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,10 @@
 //! <code>git clone https://github.com/cloudflare/boringtun.git</code>
 
 pub mod crypto;
+
+#[cfg(not(target_os = "windows"))]
 pub mod device;
+
 pub mod ffi;
 pub mod noise;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 //! <code>git clone https://github.com/cloudflare/boringtun.git</code>
 
 pub mod crypto;
+pub mod device;
 pub mod ffi;
 pub mod noise;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 pub mod crypto;
+
+#[cfg(not(target_os = "windows"))]
 pub mod device;
+
 pub mod ffi;
 pub mod noise;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 pub mod crypto;
-mod device;
+pub mod device;
 pub mod ffi;
 pub mod noise;
 


### PR DESCRIPTION
As mentioned in issue #136, I'd like to make `device` mod to be accessible when **boringtun** is used as library.