### PR TITLE
Fix #138 by re-supporting Android build.

### DIFF
--- a/src/device/udp_unix.rs
+++ b/src/device/udp_unix.rs
@@ -65,7 +65,7 @@ impl UDPSocket {
                 #[cfg(not(target_os = "linux"))]
                 SO_REUSEPORT,
                 &1u32 as *const u32 as *const c_void,
-                std::mem::size_of::<u32>() as u32,
+                std::mem::size_of::<u32>() as socklen_t,
             )
         } {
             -1 => Err(Error::SetSockOpt(errno_str())),
@@ -134,7 +134,7 @@ impl UDPSocket {
             bind(
                 self.fd,
                 &addr as *const sockaddr_in as *const sockaddr,
-                std::mem::size_of::<sockaddr_in>() as u32,
+                std::mem::size_of::<sockaddr_in>() as socklen_t,
             )
         } {
             -1 => Err(Error::Bind(errno_str())),
@@ -151,7 +151,7 @@ impl UDPSocket {
             bind(
                 self.fd,
                 &addr as *const sockaddr_in6 as *const sockaddr,
-                std::mem::size_of::<sockaddr_in6>() as u32,
+                std::mem::size_of::<sockaddr_in6>() as socklen_t,
             )
         } {
             -1 => Err(Error::Bind(errno_str())),
@@ -186,7 +186,7 @@ impl UDPSocket {
             connect(
                 self.fd,
                 &addr as *const sockaddr_in as *const sockaddr,
-                std::mem::size_of::<sockaddr_in>() as u32,
+                std::mem::size_of::<sockaddr_in>() as socklen_t,
             )
         } {
             -1 => Err(Error::Connect(errno_str())),
@@ -205,7 +205,7 @@ impl UDPSocket {
             connect(
                 self.fd,
                 &addr as *const sockaddr_in6 as *const sockaddr,
-                std::mem::size_of::<sockaddr_in6>() as u32,
+                std::mem::size_of::<sockaddr_in6>() as socklen_t,
             )
         } {
             -1 => Err(Error::Connect(errno_str())),

--- a/src/jni.rs
+++ b/src/jni.rs
@@ -143,7 +143,7 @@ pub unsafe extern "C" fn create_new_tunnel(
         Err(_) => return 0,
     };
 
-    let tunnel = new_tunnel(secret_key, public_key, Some(log_print), 3);
+    let tunnel = new_tunnel(secret_key, public_key, 0, Some(log_print), 3);
 
     if tunnel.is_null() {
         return 0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 
 pub mod crypto;
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(any(target_os = "windows", target_os = "android")))]
 pub mod device;
 
 pub mod ffi;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@
 
 pub mod crypto;
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(any(target_os = "windows", target_os = "android")))]
 pub mod device;
 
 pub mod ffi;


### PR DESCRIPTION
Some recent commits broke support for Android. I fixed what I could, and then dropped what I couldn't (the newly-exported device API, which relies on epoll, which is using timerfd, which is strangely not available in Rust's libc for Android).