### PR TITLE
Removed asserts followed by error handling

### DIFF
--- a/src/crypto/blake2s/mod.rs
+++ b/src/crypto/blake2s/mod.rs
@@ -371,8 +371,6 @@ impl Blake2s {
 
 /// Checks if both MACs are equal in constant time.
 pub fn constant_time_mac_check(mac1: &[u8], mac2: &[u8]) -> Result<(), WireGuardError> {
-    assert!(mac1.len() == 16);
-    assert!(mac2.len() == 16);
     if mac1.len() != 16 || mac2.len() != 16 {
         return Err(WireGuardError::InvalidMac);
     }


### PR DESCRIPTION
The removed asserts resulted in the error handling code being
unreachable.

Should panicking in the case of MACs with a wrong length be the desired behavior, the panic handling code should be removed and the doc comment should clarify that the function panicks in this case. If this is desired I can open another PR.