### PR TITLE
Fix memory leak in epoll/kqueue implementations.

### DIFF
--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -379,17 +379,9 @@ impl Device {
 
     fn open_listen_socket(&mut self, mut port: u16) -> Result<(), Error> {
         // Binds the network facing interfaces
-        // First close any existing open socket, and remove them from the event loop
-        self.udp4.take().and_then(|s| unsafe {
-            // This is safe because the event loop is not running yet
-            self.queue.clear_event_by_fd(s.as_raw_fd());
-            Some(())
-        });
-
-        self.udp6.take().and_then(|s| unsafe {
-            self.queue.clear_event_by_fd(s.as_raw_fd());
-            Some(())
-        });
+        // First close any existing open socket
+        self.udp4.take();
+        self.udp6.take();
 
         for peer in self.peers.values() {
             peer.shutdown_endpoint();


### PR DESCRIPTION
The way epoll/kqueue currently work is that when an event is triggered, they return a pointer to a chunk of memory that contains info about the event. It can happen that:
1. a read event is triggered on a socket
2. the socket's fd is closed
3. another connection is made with the same fd, freeing the memory of the previous event
4. the read event is actioned and the freed memory (now being used for something else) is accessed

This PR fixes the issue by assigning events unique ids independent of the socket's fd.