### PR TITLE
Correctly initialize new handshake when peer stops replying.

### DIFF
--- a/src/noise/mod.rs
+++ b/src/noise/mod.rs
@@ -402,10 +402,6 @@ impl Tunn {
 
         self.set_current_session(r_idx);
 
-        // Exclude Keepalive packets from timer update.
-        if decapsulated_packet.len() != 0 {
-            self.timer_tick(TimerName::TimeLastDataPacketReceived);
-        }
         self.timer_tick(TimerName::TimeLastPacketReceived);
 
         Ok(self.validate_decapsulated_packet(decapsulated_packet))
@@ -489,6 +485,7 @@ impl Tunn {
             return TunnResult::Err(WireGuardError::InvalidPacket);
         }
 
+        self.timer_tick(TimerName::TimeLastDataPacketReceived);
         self.rx_bytes.fetch_add(computed_len, Ordering::Relaxed);
 
         match src_ip_address {

--- a/src/noise/mod.rs
+++ b/src/noise/mod.rs
@@ -199,7 +199,10 @@ impl Tunn {
             // Send the packet using an established session
             let packet = session.format_packet_data(src, dst);
             self.timer_tick(TimerName::TimeLastPacketSent);
-            self.timer_tick(TimerName::TimeLastDataPacketSent);
+            // Exclude Keepalive packets from timer update.
+            if src.len() != 0 {
+                self.timer_tick(TimerName::TimeLastDataPacketSent);
+            }
             self.tx_bytes.fetch_add(src.len(), Ordering::Relaxed);
             return TunnResult::WriteToNetwork(packet);
         }
@@ -399,7 +402,10 @@ impl Tunn {
 
         self.set_current_session(r_idx);
 
-        self.timer_tick(TimerName::TimeLastDataPacketReceived);
+        // Exclude Keepalive packets from timer update.
+        if decapsulated_packet.len() != 0 {
+            self.timer_tick(TimerName::TimeLastDataPacketReceived);
+        }
         self.timer_tick(TimerName::TimeLastPacketReceived);
 
         Ok(self.validate_decapsulated_packet(decapsulated_packet))

--- a/src/noise/timers.rs
+++ b/src/noise/timers.rs
@@ -264,8 +264,8 @@ impl Tunn {
                 // If we have sent a packet to a given peer but have not received a
                 // packet after from that peer for (KEEPALIVE + REKEY_TIMEOUT) ms,
                 // we initiate a new handshake.
-                if aut_packet_sent > aut_packet_received
-                    && aut_packet_sent - aut_packet_received >= KEEPALIVE_TIMEOUT + REKEY_TIMEOUT
+                if data_packet_sent > aut_packet_received
+                    && now - aut_packet_received >= KEEPALIVE_TIMEOUT + REKEY_TIMEOUT
                     && timers.want_handshake.swap(false, Ordering::Relaxed)
                 {
                     debug!(self.logger, "HANDSHAKE(KEEPALIVE + REKEY_TIMEOUT)");
@@ -275,8 +275,8 @@ impl Tunn {
                 if !handshake_initiation_required {
                     // If a packet has been received from a given peer, but we have not sent one back
                     // to the given peer in KEEPALIVE ms, we send an empty packet.
-                    if aut_packet_received > aut_packet_sent
-                        && now - aut_packet_received >= KEEPALIVE_TIMEOUT
+                    if data_packet_received > aut_packet_sent
+                        && now - aut_packet_sent >= KEEPALIVE_TIMEOUT
                         && timers.want_keepalive.swap(false, Ordering::Relaxed)
                     {
                         debug!(self.logger, "KEEPALIVE(KEEPALIVE_TIMEOUT)");

--- a/src/noise/timers.rs
+++ b/src/noise/timers.rs
@@ -265,7 +265,7 @@ impl Tunn {
                 // packet after from that peer for (KEEPALIVE + REKEY_TIMEOUT) ms,
                 // we initiate a new handshake.
                 if aut_packet_sent > aut_packet_received
-                    && now - aut_packet_sent >= KEEPALIVE_TIMEOUT + REKEY_TIMEOUT
+                    && aut_packet_sent - aut_packet_received >= KEEPALIVE_TIMEOUT + REKEY_TIMEOUT
                     && timers.want_handshake.swap(false, Ordering::Relaxed)
                 {
                     debug!(self.logger, "HANDSHAKE(KEEPALIVE + REKEY_TIMEOUT)");


### PR DESCRIPTION
When a peer does not send a reply packet after `KEEPALIVE + REKEY_TIMEOUT` a new handshake should be sent.

Without this change a handshake will only be sent if no packet is sent for `KEEPALIVE + REKEY_TIMEOUT` (10 + 5 = 15 seconds). That behavior would effectively place the time to send a new handshake at `REKEY_AFTER_TIME` (120 seconds).