### PR TITLE
Fix Android build.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,9 +25,6 @@ jobs:
     demands: agent.name -equals intelmac
   continueOnError: true
   steps:
-  - script: |
-      brew install wireguard-go wireguard-tools
-    displayName: 'Install wireguard-go'
   - template: ci/azure-build.yml
   - script: |
       export PATH=$PATH:$HOME/.cargo/bin
@@ -47,9 +44,6 @@ jobs:
     demands: agent.name -equals m1mac
   continueOnError: true
   steps:
-  - script: |
-      brew install wireguard-go wireguard-tools
-    displayName: 'Install wireguard-go'
   - template: ci/azure-build.yml
   - script: |
       export PATH=$PATH:$HOME/.cargo/bin
@@ -72,6 +66,12 @@ jobs:
       sudo apt-get update
       sudo apt-get install wireguard -y
     displayName: 'Install wireguard'
+  - script: |
+      sudo apt-get install jq -y
+      sudo sh -c "cat /etc/docker/daemon.json | jq --arg cidr \"2001:db8:1::/64\" '. + {ipv6: true, \"fixed-cidr-v6\": \$cidr}' > temp.txt"
+      sudo mv temp.txt /etc/docker/daemon.json
+      sudo systemctl restart docker
+    displayName: 'Fix docker'
   - template: ci/azure-build.yml
   - script: |
       export PATH=$PATH:$HOME/.cargo/bin

--- a/src/jni.rs
+++ b/src/jni.rs
@@ -7,7 +7,7 @@ use std::ptr;
 
 use jni::objects::{JByteBuffer, JClass, JString};
 use jni::strings::JNIStr;
-use jni::sys::{jbyteArray, jint, jlong, jstring};
+use jni::sys::{jbyteArray, jint, jlong, jstring, jshort};
 use jni::JNIEnv;
 
 use crate::crypto::x25519::X25519SecretKey;
@@ -132,6 +132,8 @@ pub unsafe extern "C" fn create_new_tunnel(
     _class: JClass,
     arg_secret_key: JString,
     arg_public_key: JString,
+    keep_alive: jshort,
+    index: jint,
 ) -> jlong {
     let secret_key = match env.get_string_utf_chars(arg_secret_key) {
         Ok(v) => v,
@@ -143,7 +145,12 @@ pub unsafe extern "C" fn create_new_tunnel(
         Err(_) => return 0,
     };
 
-    let tunnel = new_tunnel(secret_key, public_key, Some(log_print), 3);
+    let tunnel = new_tunnel(secret_key,
+                            public_key,
+                            keep_alive as u16,
+                            index as u32,
+                            Some(log_print),
+                            3);
 
     if tunnel.is_null() {
         return 0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 
 pub mod crypto;
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(any(target_os = "windows", target_os = "android")))]
 pub mod device;
 
 pub mod ffi;


### PR DESCRIPTION
Skips compiling device module as tunnel device is not created on Android targets and uses the modified new_tunnel() function with additional args.