### PR TITLE
Add support for unprivileged user namespaces

### DIFF
--- a/src/device/api.rs
+++ b/src/device/api.rs
@@ -9,10 +9,9 @@ use hex::encode as encode_hex;
 use libc::*;
 use std::fs::{create_dir, remove_file};
 use std::io::{BufRead, BufReader, BufWriter, Write};
-use std::os::unix::io::AsRawFd;
+use std::os::unix::io::{AsRawFd, FromRawFd};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::sync::atomic::Ordering;
-use std::os::unix::io::FromRawFd;
 
 const SOCK_DIR: &str = "/var/run/wireguard/";
 
@@ -79,8 +78,7 @@ impl<T: Tun, S: Sock> Device<T, S> {
     }
 
     pub fn register_api_fd(&mut self, fd: i32) -> Result<(), Error> {
-
-        let io_file = unsafe {UnixStream::from_raw_fd(fd)};
+        let io_file = unsafe { UnixStream::from_raw_fd(fd) };
 
         self.queue.new_event(
             io_file.as_raw_fd(),

--- a/src/device/epoll.rs
+++ b/src/device/epoll.rs
@@ -382,6 +382,10 @@ impl<'a, H> EventGuard<'a, H> {
         std::mem::forget(self); // Don't call the regular drop that would enable the event
     }
 
+    pub fn fd(&self) -> i32 {
+        return self.event.fd;
+    }
+
     /// Change the event flags to enable or disable notifying when the fd is writable
     pub fn notify_writable(&mut self, enabled: bool) {
         let flags = if enabled {

--- a/src/device/integration_tests/mod.rs
+++ b/src/device/integration_tests/mod.rs
@@ -278,6 +278,8 @@ mod tests {
                     use_connected_socket: true,
                     #[cfg(target_os = "linux")]
                     use_multi_queue: true,
+                    #[cfg(target_os = "linux")]
+                    uapi_fd: -1,
                 },
             )
         }
@@ -294,7 +296,6 @@ mod tests {
                 addr_v6,
                 started: false,
                 peers: vec![],
-                uapi_fd: -1,
             }
         }
 
@@ -569,6 +570,7 @@ mod tests {
                 use_connected_socket: false,
                 #[cfg(target_os = "linux")]
                 use_multi_queue: true,
+                #[cfg(target_os = "linux")]
                 uapi_fd: -1,
             },
         );
@@ -730,6 +732,7 @@ mod tests {
                 use_connected_socket: false,
                 #[cfg(target_os = "linux")]
                 use_multi_queue: true,
+                #[cfg(target_os = "linux")]
                 uapi_fd: -1,
             },
         );

--- a/src/device/integration_tests/mod.rs
+++ b/src/device/integration_tests/mod.rs
@@ -294,6 +294,7 @@ mod tests {
                 addr_v6,
                 started: false,
                 peers: vec![],
+                uapi_fd: -1,
             }
         }
 
@@ -568,6 +569,7 @@ mod tests {
                 use_connected_socket: false,
                 #[cfg(target_os = "linux")]
                 use_multi_queue: true,
+                uapi_fd: -1,
             },
         );
 
@@ -728,6 +730,7 @@ mod tests {
                 use_connected_socket: false,
                 #[cfg(target_os = "linux")]
                 use_multi_queue: true,
+                uapi_fd: -1,
             },
         );
 

--- a/src/device/kqueue.rs
+++ b/src/device/kqueue.rs
@@ -328,4 +328,9 @@ impl<'a, H> EventGuard<'a, H> {
         unsafe { self.poll.clear_event_by_fd(self.event.event.ident as RawFd) };
         std::mem::forget(self); // Don't call the regular drop that would enable the event
     }
+
+    /// Stub: only used for Linux-specific features.
+    pub fn fd(&self) -> i32 {
+        return -1;
+    }
 }

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -411,7 +411,7 @@ impl<T: Tun, S: Sock> Device<T, S> {
             cleanup_paths: Default::default(),
             mtu: AtomicUsize::new(mtu),
             rate_limiter: None,
-            uapi_fd
+            uapi_fd,
         };
 
         if uapi_fd >= 0 {

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -134,6 +134,7 @@ pub struct DeviceConfig {
     pub logger: Logger,
     #[cfg(target_os = "linux")]
     pub use_multi_queue: bool,
+    #[cfg(target_os = "linux")]
     pub uapi_fd: i32,
 }
 
@@ -145,6 +146,7 @@ impl Default for DeviceConfig {
             logger: Logger::root(Discard, o!()),
             #[cfg(target_os = "linux")]
             use_multi_queue: true,
+            #[cfg(target_os = "linux")]
             uapi_fd: -1,
         }
     }
@@ -255,6 +257,9 @@ impl<T: Tun, S: Sock> DeviceHandle<T, S> {
             iface: Arc::clone(&device.read().iface),
         };
 
+        #[cfg(not(target_os = "linux"))]
+        let uapi_fd = -1;
+        #[cfg(target_os = "linux")]
         let uapi_fd = device.read().uapi_fd;
 
         loop {
@@ -383,6 +388,9 @@ impl<T: Tun, S: Sock> Device<T, S> {
         let iface = Arc::new(T::new(name)?.set_non_blocking()?);
         let mtu = iface.mtu()?;
 
+        #[cfg(not(target_os = "linux"))]
+        let uapi_fd = -1;
+        #[cfg(target_os = "linux")]
         let uapi_fd = config.uapi_fd;
 
         let mut device = Device {

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -179,6 +179,7 @@ pub struct Device<T: Tun, S: Sock> {
 
     rate_limiter: Option<Arc<RateLimiter>>,
 
+    #[cfg(target_os = "linux")]
     uapi_fd: i32,
 }
 
@@ -411,6 +412,7 @@ impl<T: Tun, S: Sock> Device<T, S> {
             cleanup_paths: Default::default(),
             mtu: AtomicUsize::new(mtu),
             rate_limiter: None,
+            #[cfg(target_os = "linux")]
             uapi_fd,
         };
 

--- a/src/device/tun_linux.rs
+++ b/src/device/tun_linux.rs
@@ -81,7 +81,7 @@ impl Tun for TunSocket {
         if provided_fd.is_ok() {
             return Ok(TunSocket {
                 fd: provided_fd.unwrap(),
-                name: name.to_string()
+                name: name.to_string(),
             });
         }
 

--- a/src/device/tun_linux.rs
+++ b/src/device/tun_linux.rs
@@ -76,11 +76,13 @@ impl TunSocket {
 
 impl Tun for TunSocket {
     fn new(name: &str) -> Result<TunSocket, Error> {
-
         // If the provided name appears to be a FD, use that.
         let provided_fd = name.parse::<i32>();
         if provided_fd.is_ok() {
-            return Ok(TunSocket { fd: provided_fd.unwrap(), name: name.to_string() });
+            return Ok(TunSocket {
+                fd: provided_fd.unwrap(),
+                name: name.to_string()
+            });
         }
 
         let fd = match unsafe { open(b"/dev/net/tun\0".as_ptr() as _, O_RDWR) } {
@@ -125,7 +127,6 @@ impl Tun for TunSocket {
 
     /// Get the current MTU value
     fn mtu(&self) -> Result<usize, Error> {
-
         let provided_fd = self.name.parse::<i32>();
         if provided_fd.is_ok() {
             return Ok(1500);

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,6 +94,7 @@ fn main() {
         .get_matches();
 
     let background = !matches.is_present("foreground");
+    #[cfg(target_os = "linux")]
     let uapi_fd = value_t!(matches.value_of("uapi-fd"), i32).unwrap_or_else(|e| e.exit());
     let tun_fd = value_t!(matches.value_of("tun-fd"), isize).unwrap_or_else(|e| e.exit());
     let mut tun_name = matches.value_of("INTERFACE_NAME").unwrap();
@@ -154,6 +155,7 @@ fn main() {
     let config = DeviceConfig {
         n_threads,
         logger: logger.clone(),
+        #[cfg(target_os = "linux")]
         uapi_fd: uapi_fd,
         use_connected_socket: !matches.is_present("disable-connected-udp"),
         #[cfg(target_os = "linux")]


### PR DESCRIPTION
This PR provides the scaffolding needed for unprivileged user namespaces to leverage wireguard.  It adds the ability for the invoking process to pass file descriptors corresponding to a TUN device and a Unix socketpair.

With this, I've been able to demonstrate the `boringtun` executable used as a VPN client and server _without_ any root-level privileges on either server or client side.

(PS - I am not rust literate; please forgive in advance any C-stylings that have snuck in)

Fixes #168