### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/crypto/blake2s/mod.rs
+++ b/src/crypto/blake2s/mod.rs
@@ -357,8 +357,9 @@ impl Blake2s {
 
         // Convert the internal state from a [u32; 8] to a [u8; 32].
         let mut s = [0u8; 32];
+        #[allow(clippy::needless_range_loop)]
         for i in 0..self.outlen {
-            s[i] = (self.state[i / 4] >> 8 * (i % 4)) as u8;
+            s[i] = (self.state[i / 4] >> (8 * (i % 4))) as u8;
         }
 
         // Return the final output.

--- a/src/crypto/x25519/mod.rs
+++ b/src/crypto/x25519/mod.rs
@@ -489,7 +489,7 @@ fn sqr_256(x: Felem) -> Felem2 {
 
 #[inline(always)]
 fn mod_25519(x: Felem2) -> Felem {
-    let c38 = 38 as u128;
+    let c38 = 38_u128;
 
     let mut acc0 = u128::from(x.0[0]);
     let mut acc1 = u128::from(x.0[1]);
@@ -638,7 +638,7 @@ fn x25519_shared_key(peer_key: &[u8], secret_key: &[u8]) -> [u8; 32] {
 
     let mut scalar = [0_u8; 32];
     let mut shared_key = [0_u8; 32];
-    scalar[..].copy_from_slice(&secret_key[..]);
+    scalar[..].copy_from_slice(secret_key);
 
     assert!(peer_key.len() == 32);
     let u = Felem([

--- a/src/device/api.rs
+++ b/src/device/api.rs
@@ -164,7 +164,7 @@ fn api_get<T: Tun, S: Sock>(writer: &mut BufWriter<&UnixStream>, d: &Device<T, S
     0
 }
 
-fn api_set<'a, T: Tun, S: Sock>(
+fn api_set<T: Tun, S: Sock>(
     reader: &mut BufReader<&UnixStream>,
     d: &mut LockReadGuard<Device<T, S>>,
 ) -> i32 {
@@ -175,7 +175,7 @@ fn api_set<'a, T: Tun, S: Sock>(
 
             let mut cmd = String::new();
 
-            while let Ok(_) = reader.read_line(&mut cmd) {
+            while reader.read_line(&mut cmd).is_ok() {
                 cmd.pop(); // remove newline if any
                 if cmd.is_empty() {
                     return 0; // Done
@@ -243,7 +243,7 @@ fn api_set_peer<T: Tun, S: Sock>(
     let mut preshared_key = None;
     let mut allowed_ips: Vec<AllowedIP> = vec![];
 
-    while let Ok(_) = reader.read_line(&mut cmd) {
+    while reader.read_line(&mut cmd).is_ok() {
         cmd.pop(); // remove newline if any
         if cmd.is_empty() {
             d.update_peer(

--- a/src/device/epoll.rs
+++ b/src/device/epoll.rs
@@ -329,10 +329,13 @@ impl<H: Sync + Send> EventPoll<H> {
 }
 
 impl<H> EventPoll<H> {
-    /// Disable and remove the event and associated handler, using the fd that was used
-    /// to register it.
-    /// This function is only safe to call when the event loop is not running, otherwise the
-    /// memory of the handler may get freed while in use.
+    /// Disable and remove the event and associated handler, using the fd that
+    /// was used to register it.
+    ///
+    /// # Safety
+    ///
+    /// This function is only safe to call when the event loop is not running,
+    /// otherwise the memory of the handler may get freed while in use.
     pub unsafe fn clear_event_by_fd(&self, index: RawFd) {
         let mut events = self.events.lock();
         assert!(index >= 0);

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -415,16 +415,16 @@ impl<T: Tun, S: Sock> Device<T, S> {
     fn open_listen_socket(&mut self, mut port: u16) -> Result<(), Error> {
         // Binds the network facing interfaces
         // First close any existing open socket, and remove them from the event loop
-        self.udp4.take().and_then(|s| unsafe {
-            // This is safe because the event loop is not running yet
-            self.queue.clear_event_by_fd(s.as_raw_fd());
-            Some(())
-        });
+        if let Some(s) = self.udp4.take() {
+            unsafe {
+                // This is safe because the event loop is not running yet
+                self.queue.clear_event_by_fd(s.as_raw_fd())
+            }
+        };
 
-        self.udp6.take().and_then(|s| unsafe {
-            self.queue.clear_event_by_fd(s.as_raw_fd());
-            Some(())
-        });
+        if let Some(s) = self.udp6.take() {
+            unsafe { self.queue.clear_event_by_fd(s.as_raw_fd()) };
+        }
 
         for peer in self.peers.values() {
             peer.shutdown_endpoint();

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -1,6 +1,10 @@
 // Copyright (c) 2019 Cloudflare, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
+// Requiring explicit per-fn "Safety" docs not worth it. Just pass in valid
+// pointers and buffers/lengths to these, ok?
+#![allow(clippy::missing_safety_doc)]
+
 /// C bindings for the BoringTun library
 pub mod benchmark;
 use self::benchmark::do_benchmark;

--- a/src/noise/handshake.rs
+++ b/src/noise/handshake.rs
@@ -292,10 +292,7 @@ impl Handshake {
     }
 
     pub(crate) fn is_in_progress(&self) -> bool {
-        match self.state {
-            HandshakeState::None | HandshakeState::Expired => false,
-            _ => true,
-        }
+        !matches!(self.state, HandshakeState::None | HandshakeState::Expired)
     }
 
     pub(crate) fn timer(&self) -> Option<Instant> {
@@ -311,10 +308,7 @@ impl Handshake {
     }
 
     pub(crate) fn is_expired(&self) -> bool {
-        match self.state {
-            HandshakeState::Expired => true,
-            _ => false,
-        }
+        matches!(self.state, HandshakeState::Expired)
     }
 
     pub(crate) fn has_cookie(&self) -> bool {

--- a/src/noise/mod.rs
+++ b/src/noise/mod.rs
@@ -200,7 +200,7 @@ impl Tunn {
             let packet = session.format_packet_data(src, dst);
             self.timer_tick(TimerName::TimeLastPacketSent);
             // Exclude Keepalive packets from timer update.
-            if src.len() != 0 {
+            if !src.is_empty() {
                 self.timer_tick(TimerName::TimeLastDataPacketSent);
             }
             self.tx_bytes.fetch_add(src.len(), Ordering::Relaxed);
@@ -568,11 +568,7 @@ impl Tunn {
     /// * Data bytes sent
     /// * Data bytes received
     pub fn stats(&self) -> (Option<u64>, usize, usize, f32, Option<u32>) {
-        let time = if let Some(time) = self.time_since_last_handshake() {
-            Some(time.as_secs())
-        } else {
-            None
-        };
+        let time = self.time_since_last_handshake().map(|t| t.as_secs());
         let tx_bytes = self.tx_bytes.load(Ordering::Relaxed);
         let rx_bytes = self.rx_bytes.load(Ordering::Relaxed);
         let loss = self.estimate_loss();


### PR DESCRIPTION
Straightforward, except one spot where Clippy make things worse, and
another spot where requiring per-fn docs was not really valuable.