### PR TITLE
AllowedIps: Use ip_network_table instead of homegrown trie impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,8 @@ dependencies = [
  "clap",
  "daemonize",
  "hex",
+ "ip_network",
+ "ip_network_table",
  "jni",
  "libc",
  "parking_lot",
@@ -295,6 +297,28 @@ name = "hex"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
+
+[[package]]
+name = "ip_network"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee15951c035f79eddbef745611ec962f63f4558f1dadf98ab723cc603487c6f"
+
+[[package]]
+name = "ip_network_table"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa59c26e61245c366c7d615b56524cdc7c9104ba15c0ebfc0f09ddb8cdf728be"
+dependencies = [
+ "ip_network",
+ "ip_network_table-deps-treebitmap",
+]
+
+[[package]]
+name = "ip_network_table-deps-treebitmap"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e537132deb99c0eb4b752f0346b6a836200eaaa3516dd7e5514b63930a09e5d"
 
 [[package]]
 name = "jni"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ libc = "0.2"
 parking_lot = "0.10"
 slog = "2.5"
 slog-term = "2.5"
+ip_network = "0.3.4"
+ip_network_table = "0.1.2"
 
 [target.'cfg(not(target_arch="arm"))'.dependencies]
 ring = "0.16"

--- a/src/device/api.rs
+++ b/src/device/api.rs
@@ -147,7 +147,7 @@ fn api_get<T: Tun, S: Sock>(writer: &mut BufWriter<&UnixStream>, d: &Device<T, S
             writeln!(writer, "endpoint={}", addr);
         }
 
-        for (_, ip, cidr) in p.allowed_ips() {
+        for (ip, cidr) in p.allowed_ips() {
             writeln!(writer, "allowed_ip={}/{}", ip, cidr);
         }
 

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -385,7 +385,7 @@ impl<T: Tun, S: Sock> Device<T, S> {
             next_index: Default::default(),
             peers: Default::default(),
             peers_by_idx: Default::default(),
-            peers_by_ip: Default::default(),
+            peers_by_ip: AllowedIps::new(),
             udp4: Default::default(),
             udp6: Default::default(),
             cleanup_paths: Default::default(),


### PR DESCRIPTION
`ip_network_table` crate is exactly what we need so use it instead of
own trie impl. Big code/complexity reduction. Keep all unit tests.

This in turn uses `ip_network` and `treebitmap` crates, these both
look good too. (wireguard-rs also uses these, fwiw.)

Make small changes to rest of code as needed. AllowedIps interface is
mostly the same but I couldn't resist a few tweaks.