### PR TITLE
Switch from slog to tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,21 +18,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "ascii"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "autocfg"
@@ -80,8 +78,9 @@ dependencies = [
  "libc",
  "parking_lot",
  "ring",
- "slog",
- "slog-term",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
  "untrusted",
 ]
 
@@ -166,6 +165,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+dependencies = [
+ "cfg-if 1.0.0",
+ "lazy_static",
+]
+
+[[package]]
 name = "daemonize"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -173,27 +192,6 @@ checksum = "70c24513e34f53b640819f0ac9f705b673fcf4006d7aab8778bee72ebfc89815"
 dependencies = [
  "boxfnonce",
  "libc",
-]
-
-[[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if 1.0.0",
- "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
 ]
 
 [[package]]
@@ -213,30 +211,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "wasi",
-]
-
-[[package]]
 name = "gimli"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hex"
@@ -274,6 +252,12 @@ name = "ip_network_table-deps-treebitmap"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e537132deb99c0eb4b752f0346b6a836200eaaa3516dd7e5514b63930a09e5d"
+
+[[package]]
+name = "itoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "jni"
@@ -332,6 +316,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
  "cfg-if 0.1.10",
+]
+
+[[package]]
+name = "matchers"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -407,6 +400,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -434,14 +433,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_users"
-version = "0.4.0"
+name = "regex"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
- "getrandom",
- "redox_syscall",
+ "regex-syntax",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "ring"
@@ -465,10 +478,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e3bad0ee36814ca07d7968269dd4b7ec89ec2da10c4bb613928d3077083c232"
 
 [[package]]
-name = "rustversion"
+name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "same-file"
@@ -486,22 +499,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
-name = "slog"
-version = "2.7.0"
+name = "serde"
+version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8347046d4ebd943127157b94d63abb990fcf729dc4e9978927fdf4ac3c998d06"
+checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
 
 [[package]]
-name = "slog-term"
-version = "2.8.0"
+name = "serde_json"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95c1e7e5aab61ced6006149ea772770b84a0d16ce0f7885def313e4829946d76"
+checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
 dependencies = [
- "atty",
- "chrono",
- "slog",
- "term",
- "thread_local",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "740223c51853f3145fe7c90360d2d4232f2b62e3449489c207eccde818979982"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -534,17 +554,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "term"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
-dependencies = [
- "dirs-next",
- "rustversion",
- "winapi",
-]
-
-[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -571,6 +580,92 @@ dependencies = [
  "libc",
  "wasi",
  "winapi",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
+dependencies = [
+ "cfg-if 1.0.0",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9965507e507f12c8901432a33e31131222abac31edd90cabbcf85cf544b7127a"
+dependencies = [
+ "chrono",
+ "crossbeam-channel",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
+dependencies = [
+ "ansi_term",
+ "chrono",
+ "lazy_static",
+ "matchers",
+ "regex",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,20 @@ hex = "0.4"
 untrusted = "0.7"
 libc = "0.2"
 parking_lot = "0.11"
-slog = "2.7"
-slog-term = { version = "2.7", optional = true }
+tracing = "0.1.29"
 ip_network = "0.3.4"
 ip_network_table = "0.1.2"
 
+[dependencies.tracing-subscriber]
+version = "0.2.25"
+optional = true
+
+[dependencies.tracing-appender]
+version = "0.1.2"
+optional = true
+
 [dev-dependencies]
-slog-term = { version = "2.7" }
+tracing-subscriber = "0.2.25"
 
 [target.'cfg(not(target_arch="arm"))'.dependencies]
 ring = "0.16"
@@ -33,7 +40,7 @@ jni = "0.10"
 
 [features]
 default = ["build-binary"]
-build-binary = ["slog-term", "clap", "daemonize"]
+build-binary = ["tracing-subscriber", "tracing-appender", "clap", "daemonize"]
 
 [lib]
 crate-type = ["lib", "staticlib", "dylib"]

--- a/src/device/integration_tests/mod.rs
+++ b/src/device/integration_tests/mod.rs
@@ -11,7 +11,6 @@ mod tests {
     use hex::encode;
     #[cfg(not(target_arch = "arm"))]
     pub use ring::rand::SecureRandom;
-    use slog::{Drain, Logger};
     use std::io::{BufRead, BufReader, Read, Write};
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
     use std::os::unix::net::UnixStream;
@@ -263,19 +262,11 @@ mod tests {
     impl WGHandle {
         /// Create a new interface for the tunnel with the given address
         fn init(addr_v4: IpAddr, addr_v6: IpAddr) -> WGHandle {
-            let logger = Logger::root(
-                slog_term::FullFormat::new(slog_term::PlainSyncDecorator::new(std::io::stdout()))
-                    .build()
-                    .fuse(),
-                slog::o!(),
-            );
-
             WGHandle::init_with_config(
                 addr_v4,
                 addr_v6,
                 DeviceConfig {
                     n_threads: 2,
-                    logger,
                     use_connected_socket: true,
                     #[cfg(target_os = "linux")]
                     use_multi_queue: true,
@@ -555,19 +546,11 @@ mod tests {
         let addr_v4 = next_ip();
         let addr_v6 = next_ip_v6();
 
-        let logger = Logger::root(
-            slog_term::FullFormat::new(slog_term::PlainSyncDecorator::new(std::io::stdout()))
-                .build()
-                .fuse(),
-            slog::o!(),
-        );
-
         let mut wg = WGHandle::init_with_config(
             addr_v4,
             addr_v6,
             DeviceConfig {
                 n_threads: 2,
-                logger,
                 use_connected_socket: false,
                 #[cfg(target_os = "linux")]
                 use_multi_queue: true,
@@ -717,19 +700,11 @@ mod tests {
         let addr_v4 = next_ip();
         let addr_v6 = next_ip_v6();
 
-        let logger = Logger::root(
-            slog_term::FullFormat::new(slog_term::PlainSyncDecorator::new(std::io::stdout()))
-                .build()
-                .fuse(),
-            slog::o!(),
-        );
-
         let mut wg = WGHandle::init_with_config(
             addr_v4,
             addr_v6,
             DeviceConfig {
                 n_threads: 2,
-                logger,
                 use_connected_socket: false,
                 #[cfg(target_os = "linux")]
                 use_multi_queue: true,

--- a/src/device/peer.rs
+++ b/src/device/peer.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 use parking_lot::RwLock;
-use slog::info;
 
 use std::net::IpAddr;
 use std::net::SocketAddr;
@@ -80,7 +79,7 @@ impl<S: Sock> Peer<S> {
 
     pub fn shutdown_endpoint(&self) {
         if let Some(conn) = self.endpoint.write().conn.take() {
-            info!(self.tunnel.logger, "Disconnecting from endpoint");
+            tracing::info!("Disconnecting from endpoint");
             conn.shutdown();
         }
     }
@@ -125,11 +124,10 @@ impl<S: Sock> Peer<S> {
             udp_conn.set_fwmark(fwmark)?;
         }
 
-        info!(
-            self.tunnel.logger,
-            "Connected endpoint :{}->{}",
-            port,
-            endpoint.addr.unwrap()
+        tracing::info!(
+            message="Connected endpoint",
+            port=port,
+            endpoint=?endpoint.addr.unwrap()
         );
 
         endpoint.conn = Some(Arc::clone(&udp_conn));

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -13,7 +13,6 @@ use crate::crypto::{X25519PublicKey, X25519SecretKey};
 use base64::{decode, encode};
 use hex::encode as encode_hex;
 use libc::{raise, SIGSEGV};
-use slog::{o, Drain, Level, Logger};
 
 use std::ffi::{CStr, CString};
 use std::mem;
@@ -84,22 +83,6 @@ impl<'a> From<TunnResult<'a>> for wireguard_result {
                 size: b.len(),
             },
         }
-    }
-}
-
-/// Custom slog Drain logic
-struct FFIDrain {
-    logger: unsafe extern "C" fn(*const c_char),
-}
-
-impl Drain for FFIDrain {
-    type Ok = ();
-    type Err = ();
-
-    fn log(&self, record: &slog::Record, _: &slog::OwnedKVList) -> Result<Self::Ok, Self::Err> {
-        let cstr = CString::new(format!("{}", record.msg())).unwrap();
-        unsafe { (self.logger)(cstr.as_ptr()) };
-        Ok(())
     }
 }
 
@@ -178,8 +161,6 @@ pub unsafe extern "C" fn new_tunnel(
     server_static_public: *const c_char,
     keep_alive: u16,
     index: u32,
-    log_printer: Option<unsafe extern "C" fn(*const c_char)>,
-    log_level: u32,
 ) -> *mut Tunn {
     let c_str = CStr::from_ptr(static_private);
     let static_private = match c_str.to_str() {
@@ -209,7 +190,7 @@ pub unsafe extern "C" fn new_tunnel(
         Some(keep_alive)
     };
 
-    let mut tunnel = match Tunn::new(
+    let tunnel = match Tunn::new(
         Arc::new(private_key),
         Arc::new(public_key),
         None,
@@ -220,20 +201,6 @@ pub unsafe extern "C" fn new_tunnel(
         Ok(t) => t,
         Err(_) => return ptr::null_mut(),
     };
-
-    if let Some(logger) = log_printer {
-        let level = match log_level {
-            0 => Level::Error,
-            1 => Level::Info,
-            2 => Level::Debug,
-            _ => Level::Trace,
-        };
-
-        let drain = FFIDrain { logger };
-        let logger = Logger::root(drain.filter_level(level).fuse(), o!());
-
-        tunnel.set_logger(logger);
-    }
 
     PANIC_HOOK.call_once(|| {
         // FFI won't properly unwind on panic, but it will if we cause a segmentation fault

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,6 @@ use crate::device::drop_privileges::drop_privileges;
 use crate::device::{DeviceConfig, DeviceHandle};
 use clap::{value_t, App, Arg};
 use daemonize::Daemonize;
-use slog::{error, info, o, Drain, Logger};
 use std::fs::File;
 use std::os::unix::net::UnixDatagram;
 use std::process::exit;
@@ -103,13 +102,13 @@ fn main() {
     }
     let n_threads = value_t!(matches.value_of("threads"), usize).unwrap_or_else(|e| e.exit());
     let log_level =
-        value_t!(matches.value_of("verbosity"), slog::Level).unwrap_or_else(|e| e.exit());
+        value_t!(matches.value_of("verbosity"), tracing::Level).unwrap_or_else(|e| e.exit());
 
     // Create a socketpair to communicate between forked processes
     let (sock1, sock2) = UnixDatagram::pair().unwrap();
     let _ = sock1.set_nonblocking(true);
 
-    let logger;
+    let _guard;
 
     if background {
         let log = matches.value_of("log").unwrap();
@@ -117,12 +116,15 @@ fn main() {
         let log_file =
             File::create(&log).unwrap_or_else(|_| panic!("Could not create log file {}", log));
 
-        let plain = slog_term::PlainSyncDecorator::new(log_file);
-        let drain = slog_term::CompactFormat::new(plain)
-            .build()
-            .filter_level(log_level);
-        let drain = std::sync::Mutex::new(drain).fuse();
-        logger = Logger::root(drain, o!());
+        let (non_blocking, guard) = tracing_appender::non_blocking(log_file);
+
+        _guard = guard;
+
+        tracing_subscriber::fmt()
+            .with_max_level(log_level)
+            .with_writer(non_blocking)
+            .with_ansi(false)
+            .init();
 
         let daemonize = Daemonize::new()
             .working_directory("/tmp")
@@ -137,26 +139,23 @@ fn main() {
             });
 
         match daemonize.start() {
-            Ok(_) => info!(logger, "BoringTun started successfully"),
+            Ok(_) => tracing::info!("BoringTun started successfully"),
             Err(e) => {
-                error!(logger, "Error, {}", e);
+                tracing::error!(error = ?e);
                 exit(1);
             }
         }
     } else {
-        let plain = slog_term::TermDecorator::new().stdout().build();
-        let drain = slog_term::FullFormat::new(plain)
-            .build()
-            .filter_level(log_level);
-        let drain = std::sync::Mutex::new(drain).fuse();
-        logger = Logger::root(drain, o!());
+        tracing_subscriber::fmt()
+            .pretty()
+            .with_max_level(log_level)
+            .init();
     }
 
     let config = DeviceConfig {
         n_threads,
-        logger: logger.clone(),
         #[cfg(target_os = "linux")]
-        uapi_fd: uapi_fd,
+        uapi_fd,
         use_connected_socket: !matches.is_present("disable-connected-udp"),
         #[cfg(target_os = "linux")]
         use_multi_queue: !matches.is_present("disable-multi-queue"),
@@ -166,7 +165,7 @@ fn main() {
         Ok(d) => d,
         Err(e) => {
             // Notify parent that tunnel initialization failed
-            error!(logger, "Failed to initialize tunnel: {:?}", e);
+            tracing::error!(message = "Failed to initialize tunnel", error=?e);
             sock1.send(&[0]).unwrap();
             exit(1);
         }
@@ -174,7 +173,7 @@ fn main() {
 
     if !matches.is_present("disable-drop-privileges") {
         if let Err(e) = drop_privileges() {
-            error!(logger, "Failed to drop privileges: {:?}", e);
+            tracing::error!(message = "Failed to drop privileges", error = ?e);
             sock1.send(&[0]).unwrap();
             exit(1);
         }
@@ -184,7 +183,7 @@ fn main() {
     sock1.send(&[1]).unwrap();
     drop(sock1);
 
-    info!(logger, "BoringTun started successfully");
+    tracing::info!("BoringTun started successfully");
 
     device_handle.wait();
 }

--- a/src/noise/tests/mod.rs
+++ b/src/noise/tests/mod.rs
@@ -5,7 +5,6 @@
 mod tests {
     use super::super::*;
     use base64::encode;
-    use slog::{o, Drain};
     use std::fs;
     use std::fs::File;
     use std::io::prelude::Write;
@@ -171,13 +170,12 @@ mod tests {
         network_socket: UdpSocket,
         static_private: &str,
         peer_static_public: &str,
-        logger: Logger,
         close: Arc<AtomicBool>,
     ) -> UdpSocket {
         let static_private = static_private.parse().unwrap();
         let peer_static_public = peer_static_public.parse().unwrap();
 
-        let mut peer = Tunn::new(
+        let peer = Tunn::new(
             Arc::new(static_private),
             Arc::new(peer_static_public),
             None,
@@ -186,8 +184,6 @@ mod tests {
             None,
         )
         .unwrap();
-
-        peer.set_logger(logger);
 
         let peer: Arc<Box<Tunn>> = Arc::from(peer);
 
@@ -322,28 +318,9 @@ mod tests {
         let server_pair = key_pair();
         let client_pair = key_pair();
 
-        let logger = Logger::root(
-            slog_term::FullFormat::new(slog_term::PlainSyncDecorator::new(std::io::stdout()))
-                .build()
-                .fuse(),
-            slog::o!(),
-        );
+        let s_iface = wireguard_test_peer(s_sock, &server_pair.0, &client_pair.1, close.clone());
 
-        let s_iface = wireguard_test_peer(
-            s_sock,
-            &server_pair.0,
-            &client_pair.1,
-            logger.new(o!("server" => "")),
-            close.clone(),
-        );
-
-        let c_iface = wireguard_test_peer(
-            c_sock,
-            &client_pair.0,
-            &server_pair.1,
-            logger.new(o!("client" => "")),
-            close.clone(),
-        );
+        let c_iface = wireguard_test_peer(c_sock, &client_pair.0, &server_pair.1, close.clone());
 
         (s_iface, c_iface, close)
     }
@@ -465,20 +442,8 @@ mod tests {
 
         let close = Arc::new(AtomicBool::new(false));
 
-        let logger = Logger::root(
-            slog_term::FullFormat::new(slog_term::PlainSyncDecorator::new(std::io::stdout()))
-                .build()
-                .fuse(),
-            slog::o!(),
-        );
-
-        let c_iface = wireguard_test_peer(
-            client_socket,
-            &c_key_pair.0,
-            &wg.public_key,
-            logger.new(o!()),
-            close.clone(),
-        );
+        let c_iface =
+            wireguard_test_peer(client_socket, &c_key_pair.0, &wg.public_key, close.clone());
 
         c_iface
             .set_read_timeout(Some(Duration::from_millis(1000)))
@@ -510,20 +475,8 @@ mod tests {
 
         let close = Arc::new(AtomicBool::new(false));
 
-        let logger = Logger::root(
-            slog_term::FullFormat::new(slog_term::PlainSyncDecorator::new(std::io::stdout()))
-                .build()
-                .fuse(),
-            slog::o!(),
-        );
-
-        let c_iface = wireguard_test_peer(
-            client_socket,
-            &c_key_pair.0,
-            &wg.public_key,
-            logger,
-            close.clone(),
-        );
+        let c_iface =
+            wireguard_test_peer(client_socket, &c_key_pair.0, &wg.public_key, close.clone());
 
         c_iface
             .set_read_timeout(Some(Duration::from_millis(1000)))


### PR DESCRIPTION
`slog` pulls in a lot of dependencies and isn't terribly ergonomic, and it isn't really used as much anymore now that `tracing` is a thing. This would simply things a bit.