### PR TITLE
Derive Debug, Clone and Copy for DeviceConfig

### DIFF
--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -127,6 +127,7 @@ pub struct DeviceHandle<T: Tun = TunSocket, S: Sock = UDPSocket> {
     threads: Vec<JoinHandle<()>>,
 }
 
+#[derive(Debug, Clone, Copy)
 pub struct DeviceConfig {
     pub n_threads: usize,
     pub use_connected_socket: bool,

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -127,7 +127,7 @@ pub struct DeviceHandle<T: Tun = TunSocket, S: Sock = UDPSocket> {
     threads: Vec<JoinHandle<()>>,
 }
 
-#[derive(Debug, Clone, Copy)
+#[derive(Debug, Clone, Copy)]
 pub struct DeviceConfig {
     pub n_threads: usize,
     pub use_connected_socket: bool,


### PR DESCRIPTION
Is there a reason why it's not already derived?

This will make it a little easier for library users to consume it.