### PR TITLE
ffi: change parsing behavior of null or invalid psk (#210)

### DIFF
--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -19,7 +19,7 @@ use std::mem;
 use std::os::raw::c_char;
 use std::panic;
 use std::ptr;
-use std::ptr::{null, null_mut};
+use std::ptr::null_mut;
 use std::slice;
 use std::sync::{Arc, Once};
 
@@ -176,10 +176,11 @@ pub unsafe extern "C" fn new_tunnel(
         Ok(string) => string,
     };
 
-    let c_str = CStr::from_ptr(preshared_key);
     let preshared_key = if preshared_key.is_null() {
         None
     } else {
+        let c_str = CStr::from_ptr(preshared_key);
+
         if let Ok(string) = c_str.to_str() {
             if let Ok(key) = string.parse::<X25519PublicKey>() {
                 Some(make_array(key.as_bytes()))

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -177,7 +177,7 @@ pub unsafe extern "C" fn new_tunnel(
     };
 
     let c_str = CStr::from_ptr(preshared_key);
-    let preshared_key = if preshared_key == null() {
+    let preshared_key = if preshared_key.is_null() {
         None
     } else {
         if let Ok(string) = c_str.to_str() {

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -19,6 +19,7 @@ use std::mem;
 use std::os::raw::c_char;
 use std::panic;
 use std::ptr;
+use std::ptr::{null, null_mut};
 use std::slice;
 use std::sync::{Arc, Once};
 
@@ -176,12 +177,18 @@ pub unsafe extern "C" fn new_tunnel(
     };
 
     let c_str = CStr::from_ptr(preshared_key);
-    let preshared_key = match c_str.to_str() {
-        Err(_) => None,
-        Ok(string) => match string.parse::<X25519PublicKey>() {
-            Ok(key) => Some(make_array(key.as_bytes())),
-            Err(_) => None,
-        },
+    let preshared_key = if preshared_key == null() {
+        None
+    } else {
+        if let Ok(string) = c_str.to_str() {
+            if let Ok(key) = string.parse::<X25519PublicKey>() {
+                Some(make_array(key.as_bytes()))
+            } else {
+                return null_mut();
+            }
+        } else {
+            return null_mut();
+        }
     };
 
     let private_key = match static_private.parse() {


### PR DESCRIPTION
Change the parsing behavior so that we return null if the PSK is invalid rather than failing silently or segfaulting.