### PR TITLE
emit=asm breaks clippy, and is unnecessary

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,8 +1,2 @@
-[build]
-rustflags = [
-    "-C", "llvm-args=-slp-recursion-max-depth=1024",
-    "--emit", "asm", # For whatever reason rustc produces faster code when this flag is enabled
-]
-
 [target.'cfg(unix)']
 runner = 'sudo -E'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,10 @@ jni = "0.19.0"
 default = ["build-binary"]
 build-binary = ["tracing-subscriber", "tracing-appender", "clap", "daemonize"]
 
+[profile.release]
+lto = true        # Enable full link-time optimization.
+codegen-units = 1 # Use only 1 codegen-unit to enable full optimizations.
+
 [lib]
 crate-type = ["lib", "staticlib", "dylib"]
 


### PR DESCRIPTION
> For whatever reason rustc produces faster code when this flag is enabled

That reason being that if you emit asm it forces the compiler away from ThinLTO. Whatever reason, indeed. The solution is to just tell the compiler to use full lto and a single codegen unit.