### PR TITLE
jni: allow null as preshared key

### DIFF
--- a/boringtun/src/jni.rs
+++ b/boringtun/src/jni.rs
@@ -146,9 +146,13 @@ pub unsafe extern "C" fn create_new_tunnel(
         Err(_) => return 0,
     };
 
-    let preshared_key = match env.get_string_utf_chars(arg_preshared_key) {
-        Ok(v) => v,
-        Err(_) => return 0,
+    let preshared_key = if arg_preshared_key.is_null() {
+        ptr::null_mut()
+    } else {
+        match env.get_string_utf_chars(arg_preshared_key) {
+            Ok(v) => v,
+            Err(_) => return 0,
+        }
     };
 
     let tunnel = new_tunnel(


### PR DESCRIPTION
Allows setting the `arg_preshard_key` argument for `create_new_tunnel` to `null` in order to create a tunnel without a preshared key.

Fixes #228.