### PR TITLE
structure: bring back [lib]/crate-type for library

### DIFF
--- a/boringtun/Cargo.toml
+++ b/boringtun/Cargo.toml
@@ -26,6 +26,9 @@ tracing-subscriber = "0.3"
 [target.'cfg(target_os="android")'.dependencies]
 jni = "0.19.0"
 
+[lib]
+crate-type = ["lib", "staticlib", "dylib"]
+
 [[example]]
 name = "benchmarks"
 path = "src/benchmarks_example.rs"


### PR DESCRIPTION
In 55ea9fdff6589d17c27fa9e0562bf358847d66d5, the core features of boringtun were split into a separate crate; but, in the process, the configuration from Crate.toml seems to have been shuffled around and the crate-type--which is important so this library actually builds the native library required to link it into a C application--was discarded.