### PR TITLE
Export the Poly1305 struct as public

### DIFF
--- a/boringtun/src/crypto/chacha20poly1305/mod.rs
+++ b/boringtun/src/crypto/chacha20poly1305/mod.rs
@@ -7,7 +7,7 @@ mod poly1305;
 #[cfg(test)]
 mod tests;
 
-use self::poly1305::Poly1305;
+pub use self::poly1305::Poly1305;
 use crate::noise::errors::WireGuardError;
 use crate::noise::make_array;
 use std::ops::AddAssign;

--- a/boringtun/src/crypto/mod.rs
+++ b/boringtun/src/crypto/mod.rs
@@ -9,7 +9,7 @@ mod x25519;
 
 pub use blake2s::{constant_time_mac_check, Blake2s};
 pub use chacha20poly1305::ChaCha20Poly1305;
-pub use x25519::{X25519PublicKey, X25519SecretKey};
 pub use chacha20poly1305::Poly1305;
+pub use x25519::{X25519PublicKey, X25519SecretKey};
 
 pub use ring::rand::SystemRandom;

--- a/boringtun/src/crypto/mod.rs
+++ b/boringtun/src/crypto/mod.rs
@@ -10,5 +10,6 @@ mod x25519;
 pub use blake2s::{constant_time_mac_check, Blake2s};
 pub use chacha20poly1305::ChaCha20Poly1305;
 pub use x25519::{X25519PublicKey, X25519SecretKey};
+pub use chacha20poly1305::Poly1305;
 
 pub use ring::rand::SystemRandom;


### PR DESCRIPTION
Exporting the crypto::Poly1305 struct as 'public' to match with the other crypto functions.  This will allow downstream consumers to leverage the Poly1305 code directly.