### PR TITLE
device: Allow modifying peers

### DIFF
--- a/boringtun/src/device/peer.rs
+++ b/boringtun/src/device/peer.rs
@@ -22,8 +22,8 @@ pub struct Peer {
     /// The index the tunnel uses
     index: u32,
     endpoint: RwLock<Endpoint>,
-    allowed_ips: AllowedIps<()>,
-    preshared_key: Option<[u8; 32]>,
+    allowed_ips: RwLock<AllowedIps<()>>,
+    preshared_key: RwLock<Option<[u8; 32]>>,
 }
 
 #[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug)]
@@ -65,8 +65,8 @@ impl Peer {
                 addr: endpoint,
                 conn: None,
             }),
-            allowed_ips: allowed_ips.iter().map(|ip| (ip, ())).collect(),
-            preshared_key,
+            allowed_ips: RwLock::new(allowed_ips.iter().map(|ip| (ip, ())).collect()),
+            preshared_key: RwLock::new(preshared_key),
         }
     }
 
@@ -145,11 +145,30 @@ impl Peer {
     }
 
     pub fn is_allowed_ip<I: Into<IpAddr>>(&self, addr: I) -> bool {
-        self.allowed_ips.find(addr.into()).is_some()
+        self.allowed_ips.read().find(addr.into()).is_some()
     }
 
-    pub fn allowed_ips(&self) -> impl Iterator<Item = (IpAddr, u8)> + '_ {
-        self.allowed_ips.iter().map(|(_, ip, cidr)| (ip, cidr))
+    pub fn allowed_ips(&self) -> Vec<AllowedIP> {
+        self.allowed_ips
+            .read()
+            .iter()
+            .map(|(_, ip, cidr)| AllowedIP {
+                addr: ip,
+                cidr: cidr,
+            })
+            .collect()
+    }
+
+    pub fn add_allowed_ips(&self, new_allowed_ips: &[AllowedIP]) {
+        let mut allowed_ips = self.allowed_ips.write();
+
+        for AllowedIP { addr, cidr } in new_allowed_ips {
+            allowed_ips.insert(*addr, *cidr as u32, ());
+        }
+    }
+
+    pub fn set_allowed_ips(&self, allowed_ips: &[AllowedIP]) {
+        *self.allowed_ips.write() = allowed_ips.iter().map(|ip| (ip, ())).collect();
     }
 
     pub fn time_since_last_handshake(&self) -> Option<std::time::Duration> {
@@ -160,8 +179,16 @@ impl Peer {
         self.tunnel.persistent_keepalive()
     }
 
-    pub fn preshared_key(&self) -> Option<&[u8; 32]> {
-        self.preshared_key.as_ref()
+    pub fn set_persistent_keepalive(&mut self, keepalive: u16) {
+        self.tunnel.set_persistent_keepalive(keepalive)
+    }
+
+    pub fn preshared_key(&self) -> Option<[u8; 32]> {
+        *self.preshared_key.read()
+    }
+
+    pub fn set_preshared_key(&self, key: [u8; 32]) {
+        let _ = self.preshared_key.write().replace(key);
     }
 
     pub fn index(&self) -> u32 {

--- a/boringtun/src/noise/mod.rs
+++ b/boringtun/src/noise/mod.rs
@@ -198,7 +198,7 @@ impl Tunn {
         persistent_keepalive: Option<u16>,
         index: u32,
         rate_limiter: Option<Arc<RateLimiter>>,
-    ) -> Result<Self, &'static str> {
+    ) -> Result<Self, WireGuardError> {
         let static_public = x25519::PublicKey::from(&static_private);
 
         let tunn = Tunn {
@@ -208,8 +208,7 @@ impl Tunn {
                 peer_static_public,
                 index << 8,
                 preshared_key,
-            )
-            .map_err(|_| "Invalid parameters")?,
+            )?,
             sessions: Default::default(),
             current: Default::default(),
             tx_bytes: Default::default(),

--- a/boringtun/src/noise/timers.rs
+++ b/boringtun/src/noise/timers.rs
@@ -332,4 +332,8 @@ impl Tunn {
             None
         }
     }
+
+    pub(crate) fn set_persistent_keepalive(&mut self, keepalive: u16) {
+        self.timers.persistent_keepalive = keepalive as usize;
+    }
 }


### PR DESCRIPTION
Currently, updating peers without replacing them is not implemented,
which can mess up state tracking, especially when the last handshake
time stops being a thing all of a sudden. This commit introduces API
changes to Peer to allow modifying specific fields and replaces the
panic macro with actual setting of said fields.

Fixes https://github.com/cloudflare/boringtun/issues/40