### PR TITLE
device: Make set_key() idempotent

### DIFF
--- a/boringtun/src/crypto/x25519/mod.rs
+++ b/boringtun/src/crypto/x25519/mod.rs
@@ -21,7 +21,7 @@ const MASK_63BITS: u128 = 0x7fff_ffff_ffff_ffff;
 const MASK_64BITS: u128 = 0xffff_ffff_ffff_ffff;
 
 #[repr(C)]
-#[derive(Debug, Zeroize, ZeroizeOnDrop)]
+#[derive(Debug, PartialEq, Zeroize, ZeroizeOnDrop)]
 /// A secret X25519 key.
 pub struct X25519SecretKey {
     internal: [u8; 32],

--- a/boringtun/src/device/mod.rs
+++ b/boringtun/src/device/mod.rs
@@ -449,6 +449,11 @@ impl Device {
 
         let private_key = Arc::new(private_key);
         let public_key = Arc::new(private_key.public_key());
+        let key_pair = Some((private_key.clone(), public_key.clone()));
+
+        if self.key_pair == key_pair {
+            return;
+        }
 
         let rate_limiter = Arc::new(RateLimiter::new(&public_key, HANDSHAKE_RATE_LIMIT));
 
@@ -471,7 +476,7 @@ impl Device {
             }
         }
 
-        self.key_pair = Some((private_key, public_key));
+        self.key_pair = key_pair;
         self.rate_limiter = Some(rate_limiter);
 
         // Remove all the bad peers


### PR DESCRIPTION
Calling the method with an identical private key to what is currently
set still makes the active sessions get nuked. This commit makes the
operation idempotent to avoid such situations.

Related: https://github.com/cloudflare/boringtun/issues/149