### PR TITLE
Change error conditions to WARN or ERROR

### DIFF
--- a/boringtun/src/noise/timers.rs
+++ b/boringtun/src/noise/timers.rs
@@ -289,7 +289,7 @@ impl Tunn {
                     && now - aut_packet_received >= KEEPALIVE_TIMEOUT + REKEY_TIMEOUT
                     && timers.want_handshake.swap(false, Ordering::Relaxed)
                 {
-                    tracing::error!("HANDSHAKE(KEEPALIVE + REKEY_TIMEOUT)");
+                    tracing::warn!("HANDSHAKE(KEEPALIVE + REKEY_TIMEOUT)");
                     handshake_initiation_required = true;
                 }
 

--- a/boringtun/src/noise/timers.rs
+++ b/boringtun/src/noise/timers.rs
@@ -223,7 +223,7 @@ impl Tunn {
             // All ephemeral private keys and symmetric session keys are zeroed out after
             // (REJECT_AFTER_TIME * 3) ms if no new keys have been exchanged.
             if now - session_established >= REJECT_AFTER_TIME * 3 {
-                tracing::debug!("CONNECTION_EXPIRED(REJECT_AFTER_TIME * 3)");
+                tracing::error!("CONNECTION_EXPIRED(REJECT_AFTER_TIME * 3)");
                 handshake.set_expired();
                 self.clear_all();
                 return TunnResult::Err(WireGuardError::ConnectionExpired);
@@ -236,7 +236,7 @@ impl Tunn {
                     // the retries give up and cease, and clear all existing packets queued
                     // up to be sent. If a packet is explicitly queued up to be sent, then
                     // this timer is reset.
-                    tracing::debug!("CONNECTION_EXPIRED(REKEY_ATTEMPT_TIME)");
+                    tracing::error!("CONNECTION_EXPIRED(REKEY_ATTEMPT_TIME)");
                     handshake.set_expired();
                     self.clear_all();
                     return TunnResult::Err(WireGuardError::ConnectionExpired);
@@ -248,7 +248,7 @@ impl Tunn {
                     // A handshake initiation is retried after REKEY_TIMEOUT + jitter ms,
                     // if a response has not been received, where jitter is some random
                     // value between 0 and 333 ms.
-                    tracing::debug!("HANDSHAKE(REKEY_TIMEOUT)");
+                    tracing::warn!("HANDSHAKE(REKEY_TIMEOUT)");
                     handshake_initiation_required = true;
                 }
             } else {
@@ -273,7 +273,7 @@ impl Tunn {
                         && now - session_established
                             >= REJECT_AFTER_TIME - KEEPALIVE_TIMEOUT - REKEY_TIMEOUT
                     {
-                        tracing::debug!(
+                        tracing::warn!(
                             "HANDSHAKE(REJECT_AFTER_TIME - KEEPALIVE_TIMEOUT - \
                         REKEY_TIMEOUT \
                         (on receive))"
@@ -289,7 +289,7 @@ impl Tunn {
                     && now - aut_packet_received >= KEEPALIVE_TIMEOUT + REKEY_TIMEOUT
                     && timers.want_handshake.swap(false, Ordering::Relaxed)
                 {
-                    tracing::debug!("HANDSHAKE(KEEPALIVE + REKEY_TIMEOUT)");
+                    tracing::error!("HANDSHAKE(KEEPALIVE + REKEY_TIMEOUT)");
                     handshake_initiation_required = true;
                 }
 


### PR DESCRIPTION
Currently, everything is logged at a DEBUG level. It is helpful for
debugging to have error conditions within the protocol be represented at
a higher log level. 

- CONNECTION_EXPIRED(REKEY_ATTEMPT_TIME) - ERROR
  - a new handshake could not be established after 90 seconds
- CONNECTION_EXPIRED(REJECT_AFTER_TIME * 3) - ERROR
  - a new session could not be established in 9 minutes
- HANDSHAKE(KEEPALIVE_TIMEOUT +REKEY_TIMEOUT) - ERROR
  - we sent a packet to a given peer but didn't hear back in 15 seconds.

- HANDSHAKE(REKEY_TIMEOUT) - WARN
  - the initial handshake message didnt't get a response in 5 seconds.
    This could be a symptom of network conditions, but could also
    indicate a peer under heavy load
- HANDSHAKE(REJECT_AFTER_TIME - KEEPALIVE_TIMEOUT - REKEY_TIMEOUT) - WARN
  - the receiver was the original initiator of the handshake but did not
    act on the handshake packet within 165 seconds. This could indicate
    failed responses on the receiver side
- HANDSHAKE(REJECT_AFTER_TIME - KEEPALIVE_TIMEOUT - REKEY_TIMEOUT) - WARN
  - the receiver was the original initiator of the handshake but did not
    act on the handshake packet within 165 seconds.