### PR TITLE
Do not wrap keys in Arc

### DIFF
--- a/boringtun/src/ffi/mod.rs
+++ b/boringtun/src/ffi/mod.rs
@@ -20,7 +20,7 @@ use std::panic;
 use std::ptr;
 use std::ptr::null_mut;
 use std::slice;
-use std::sync::{Arc, Once};
+use std::sync::Once;
 
 static PANIC_HOOK: Once = Once::new();
 
@@ -214,8 +214,8 @@ pub unsafe extern "C" fn new_tunnel(
     };
 
     let tunnel = match Tunn::new(
-        Arc::new(private_key),
-        Arc::new(public_key),
+        private_key,
+        public_key,
         preshared_key,
         keep_alive,
         index,

--- a/boringtun/src/noise/mod.rs
+++ b/boringtun/src/noise/mod.rs
@@ -122,20 +122,20 @@ pub enum Packet<'a> {
 impl Tunn {
     /// Create a new tunnel using own private key and the peer public key
     pub fn new(
-        static_private: Arc<x25519_dalek::StaticSecret>,
-        peer_static_public: Arc<x25519_dalek::PublicKey>,
+        static_private: x25519_dalek::StaticSecret,
+        peer_static_public: x25519_dalek::PublicKey,
         preshared_key: Option<[u8; 32]>,
         persistent_keepalive: Option<u16>,
         index: u32,
         rate_limiter: Option<Arc<RateLimiter>>,
     ) -> Result<Box<Tunn>, &'static str> {
-        let static_public = Arc::new(x25519_dalek::PublicKey::from(static_private.as_ref()));
+        let static_public = x25519_dalek::PublicKey::from(&static_private);
 
         let tunn = Tunn {
             handshake: Mutex::new(
                 Handshake::new(
                     static_private,
-                    Arc::clone(&static_public),
+                    static_public,
                     peer_static_public,
                     index << 8,
                     preshared_key,
@@ -161,8 +161,8 @@ impl Tunn {
     /// Update the private key and clear existing sessions
     pub fn set_static_private(
         &mut self,
-        static_private: Arc<x25519_dalek::StaticSecret>,
-        static_public: Arc<x25519_dalek::PublicKey>,
+        static_private: x25519_dalek::StaticSecret,
+        static_public: x25519_dalek::PublicKey,
         rate_limiter: Option<Arc<RateLimiter>>,
     ) -> Result<(), WireGuardError> {
         self.timers.should_reset_rr = rate_limiter.is_none();

--- a/boringtun/src/noise/tests.rs
+++ b/boringtun/src/noise/tests.rs
@@ -175,15 +175,7 @@ fn wireguard_test_peer(
     let static_private = static_private.parse::<KeyBytes>().unwrap().0.into();
     let peer_static_public = peer_static_public.parse::<KeyBytes>().unwrap().0.into();
 
-    let peer = Tunn::new(
-        Arc::new(static_private),
-        Arc::new(peer_static_public),
-        None,
-        None,
-        100,
-        None,
-    )
-    .unwrap();
+    let peer = Tunn::new(static_private, peer_static_public, None, None, 100, None).unwrap();
 
     let peer: Arc<Box<Tunn>> = Arc::from(peer);
 


### PR DESCRIPTION
With new key types, since they implement Copy (PublicKey) or Clone
(StaticSecret) this is not necessary. Copying 32 bytes should be less
overhead than incrementing the Arc.