### PR TITLE
noise: allow users to view current handshake state

### DIFF
--- a/boringtun/src/ffi/mod.rs
+++ b/boringtun/src/ffi/mod.rs
@@ -309,7 +309,7 @@ pub unsafe extern "C" fn wireguard_force_handshake(
 #[no_mangle]
 pub unsafe extern "C" fn wireguard_stats(tunnel: *mut Tunn) -> stats {
     let tunnel = tunnel.as_ref().unwrap();
-    let (time, tx_bytes, rx_bytes, estimated_loss, estimated_rtt) = tunnel.stats();
+    let (time, tx_bytes, rx_bytes, estimated_loss, estimated_rtt, _) = tunnel.stats();
     stats {
         time_since_last_handshake: time.map(|t| t as i64).unwrap_or(-1),
         tx_bytes,

--- a/boringtun/src/noise/handshake.rs
+++ b/boringtun/src/noise/handshake.rs
@@ -211,12 +211,13 @@ impl std::fmt::Debug for NoiseParams {
     }
 }
 
-struct HandshakeInitSentState {
+#[derive(Clone)]
+pub struct HandshakeInitSentState {
     local_index: u32,
     hash: [u8; KEY_LEN],
     chaining_key: [u8; KEY_LEN],
     ephemeral_private: x25519_dalek::ReusableSecret,
-    time_sent: Instant,
+    pub time_sent: Instant,
 }
 
 impl std::fmt::Debug for HandshakeInitSentState {
@@ -231,8 +232,8 @@ impl std::fmt::Debug for HandshakeInitSentState {
     }
 }
 
-#[derive(Debug)]
-enum HandshakeState {
+#[derive(Debug, Clone)]
+pub enum HandshakeState {
     None,                             // No handshake in process
     InitSent(HandshakeInitSentState), // We initiated the handshake
     InitReceived {
@@ -378,6 +379,10 @@ impl Handshake {
             cookies: Default::default(),
             last_rtt: None,
         })
+    }
+
+    pub(crate) fn state(&self) -> HandshakeState {
+        self.state.clone()
     }
 
     pub(crate) fn is_in_progress(&self) -> bool {

--- a/boringtun/src/noise/mod.rs
+++ b/boringtun/src/noise/mod.rs
@@ -11,7 +11,7 @@ mod tests;
 mod timers;
 
 use crate::noise::errors::WireGuardError;
-use crate::noise::handshake::Handshake;
+use crate::noise::handshake::{Handshake, HandshakeState};
 use crate::noise::rate_limiter::RateLimiter;
 use crate::noise::timers::{TimerName, Timers};
 
@@ -569,14 +569,15 @@ impl Tunn {
     /// * Time since last handshake in seconds
     /// * Data bytes sent
     /// * Data bytes received
-    pub fn stats(&self) -> (Option<u64>, usize, usize, f32, Option<u32>) {
+    pub fn stats(&self) -> (Option<u64>, usize, usize, f32, Option<u32>, HandshakeState) {
         let time = self.time_since_last_handshake().map(|t| t.as_secs());
         let tx_bytes = self.tx_bytes.load(Ordering::Relaxed);
         let rx_bytes = self.rx_bytes.load(Ordering::Relaxed);
         let loss = self.estimate_loss();
         let rtt = self.handshake.lock().last_rtt;
+        let state = self.handshake.lock().state();
 
-        (time, tx_bytes, rx_bytes, loss, rtt)
+        (time, tx_bytes, rx_bytes, loss, rtt, state)
     }
 
     pub fn is_expired(&self) -> bool {


### PR DESCRIPTION
This allows users to do things like abort connection attempts to unresponsive peers.