### PR TITLE
chore: move ci to use an `all-systems-go` job, like tokio does

### DIFF
--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -7,6 +7,19 @@ on:
     branches: [ "master" ]
 
 jobs:
+  # Depends on all actions that are required for a "successful" CI run.
+  # Based on the ci here: https://github.com/tokio-rs/tokio/blob/master/.github/workflows/ci.yml
+  all-systems-go:
+    runs-on: ubuntu-latest
+    needs:
+      - check_features
+      - clippy
+      - rustfmt
+      - tests
+      - integration-tests
+    steps:
+      - run: exit 0
+
   check_features:
     strategy:
       matrix:
@@ -19,6 +32,7 @@ jobs:
           toolchain: stable
       - uses: taiki-e/install-action@cargo-hack
       - run: cargo hack check --each-feature
+
   clippy:
     strategy:
       matrix:
@@ -31,6 +45,7 @@ jobs:
           toolchain: stable
       - uses: taiki-e/install-action@cargo-hack
       - run: cargo hack clippy --each-feature
+
   rustfmt:
     strategy:
       matrix:
@@ -42,6 +57,7 @@ jobs:
         with:
           toolchain: stable
       - run: cargo fmt --all --check
+
   tests:
     strategy:
       matrix:
@@ -54,6 +70,7 @@ jobs:
           toolchain: stable
       - uses: taiki-e/install-action@cargo-hack
       - run: cargo hack test --each-feature
+
   integration-tests:
     strategy:
       matrix:


### PR DESCRIPTION
This eases the maintenance burden of adding/removing CI jobs.