### PR TITLE
chore: ensure windows support for noise via ci

### DIFF
--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -17,8 +17,23 @@ jobs:
       - rustfmt
       - tests
       - integration-tests
+      - test-windows
     steps:
       - run: exit 0
+
+  test-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Check Windows
+        run: cargo check -p boringtun
+
+      - name: Test Windows
+        run: cargo test -p boringtun
 
   check_features:
     strategy:

--- a/boringtun/src/noise/mod.rs
+++ b/boringtun/src/noise/mod.rs
@@ -245,11 +245,7 @@ impl Tunn {
         self.inner.read().time_since_last_handshake()
     }
 
-    pub(crate) fn handle_verified_packet<'a>(
-        &self,
-        packet: Packet,
-        dst: &'a mut [u8],
-    ) -> TunnResult<'a> {
+    pub fn handle_verified_packet<'a>(&self, packet: Packet, dst: &'a mut [u8]) -> TunnResult<'a> {
         self.inner.write().handle_verified_packet(packet, dst)
     }
 


### PR DESCRIPTION
The device stuff still won't work on windows, but this will at least ensure windows compiles.