### PR TITLE
chore: prepare v0.5.1 releases for boringtun and boringtun-cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "boringtun"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "aead",
  "base64",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "boringtun-cli"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "boringtun",
  "clap 3.2.8",

--- a/boringtun-cli/Cargo.toml
+++ b/boringtun-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "boringtun-cli"
 description = "an implementation of the WireGuard® protocol designed for portability and speed"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Noah Kennedy <nkennedy@cloudflare.com>", "Andy Grover <agrover@cloudflare.com>", "Jeff Hiner <jhiner@cloudflare.com>"]
 license = "BSD-3-Clause"
 repository = "https://github.com/cloudflare/boringtun"
@@ -15,6 +15,6 @@ tracing = "0.1.31"
 tracing-subscriber = "0.3.9"
 tracing-appender = "0.2.1"
 
-# CHANGE THIS BEFORE EACH RELEASE
 [dependencies.boringtun]
+version = "0.5.1"
 path = "../boringtun"

--- a/boringtun/Cargo.toml
+++ b/boringtun/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "boringtun"
 description = "an implementation of the WireGuard® protocol designed for portability and speed"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Noah Kennedy <nkennedy@cloudflare.com>", "Andy Grover <agrover@cloudflare.com>", "Jeff Hiner <jhiner@cloudflare.com>"]
 license = "BSD-3-Clause"
 repository = "https://github.com/cloudflare/boringtun"


### PR DESCRIPTION
# v0.5.1

### Fixed

- Fix broken copy_from_slice ([#295])

[#295]: https://github.com/cloudflare/boringtun/issues/295