### PR TITLE
device: use runtime instead of compile-time environment var for macos drop privileges

### DIFF
--- a/boringtun/src/device/drop_privileges.rs
+++ b/boringtun/src/device/drop_privileges.rs
@@ -11,10 +11,19 @@ use nix::unistd::User;
 pub fn get_saved_ids() -> Result<(uid_t, gid_t), Error> {
     // Get the user name of the sudoer
     #[cfg(target_os = "macos")]
-    {
-        let uname: &'static str = env!("USER");
-        let user = User::from_name(uname).unwrap().expect("a user");
-        Ok((uid_t::from(user.uid), gid_t::from(user.gid)))
+    match std::env::var("USER") {
+        Ok(uname) => match User::from_name(&uname) {
+            Ok(Some(user)) => Ok((uid_t::from(user.uid), gid_t::from(user.gid))),
+            Err(e) => Err(Error::DropPrivileges(format!(
+                "Failed parse user; err: {:?}",
+                e
+            ))),
+            Ok(None) => Err(Error::DropPrivileges("Failed to find user".to_owned())),
+        },
+        Err(e) => Err(Error::DropPrivileges(format!(
+            "Could not get environment variable for user; err: {:?}",
+            e
+        ))),
     }
     #[cfg(not(target_os = "macos"))]
     {


### PR DESCRIPTION
In #231 we accidentally started using a compile-time environment environment variable instead of a runtime one for dropping privileges on macos. This causes privilege drops to fail when the user who is running the program does not have the same username as the user who compiled the program.

The solution here is to use the runtime variable instead.