### PR TITLE
chore: prepare v0.5.2 releases for boringtun and boringtun-cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "boringtun"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "aead",
  "base64",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "boringtun-cli"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "boringtun",
  "clap 3.2.8",

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 Boringtun is currently undergoing a restructuring. You should probably not rely on or link to 
 the master branch right now. Instead you should use the crates.io page.
 
-[![crates.io](https://img.shields.io/crates/v/boringtun.svg)](https://crates.io/crates/boringtun)
+- boringtun: [![crates.io](https://img.shields.io/crates/v/boringtun.svg)](https://crates.io/crates/boringtun)
+- boringtun-cli [![crates.io](https://img.shields.io/crates/v/boringtun-cli.svg)](https://crates.io/crates/boringtun-cli)
 
 **BoringTun** is an implementation of the [WireGuard<sup>®</sup>](https://www.wireguard.com/) protocol designed for portability and speed.
 
@@ -14,7 +15,8 @@ the master branch right now. Instead you should use the crates.io page.
 
 The project consists of two parts:
 
-* The executable `boringtun`, a [userspace WireGuard](https://www.wireguard.com/xplatform/) implementation for Linux and macOS.
+* The executable `boringtun-cli`, a [userspace WireGuard](https://www.wireguard.com/xplatform/) 
+  implementation for Linux and macOS.
 * The library `boringtun` that can be used to implement fast and efficient WireGuard client apps on various platforms, including iOS and Android. It implements the underlying WireGuard protocol, without the network or tunnel stacks, those can be implemented in a platform idiomatic way.
 
 ### Installation
@@ -22,7 +24,7 @@ The project consists of two parts:
 You can install this project using `cargo`:
 
 ```
-cargo install boringtun
+cargo install boringtun-cli
 ```
 
 ### Building
@@ -53,18 +55,18 @@ Testing this project has a few requirements:
 
 ## Supported platforms
 
-Target triple                 |Binary|Library|                 |
-------------------------------|:----:|:-----:|-----------------|
-x86_64-unknown-linux-gnu      |  ✓   |   ✓   |[![Build Status](https://dev.azure.com/cloudflare-ps/wireguard-cf/_apis/build/status/cloudflare.boringtun?branchName=master&jobName=Linux%20armv7)](https://dev.azure.com/cloudflare-ps/wireguard-cf/_build/latest?definitionId=4&branchName=master)
-aarch64-unknown-linux-gnu     |  ✓   |   ✓   |[![Build Status](https://dev.azure.com/cloudflare-ps/wireguard-cf/_apis/build/status/cloudflare.boringtun?branchName=master&jobName=Linux%20aarch64)](https://dev.azure.com/cloudflare-ps/wireguard-cf/_build/latest?definitionId=4&branchName=master)
-armv7-unknown-linux-gnueabihf |  ✓   |   ✓   |[![Build Status](https://dev.azure.com/cloudflare-ps/wireguard-cf/_apis/build/status/cloudflare.boringtun?branchName=master&jobName=Linux%20armv7)](https://dev.azure.com/cloudflare-ps/wireguard-cf/_build/latest?definitionId=4&branchName=master)
-x86_64-apple-darwin           |  ✓   |   ✓   |[![Build Status](https://dev.azure.com/cloudflare-ps/wireguard-cf/_apis/build/status/cloudflare.boringtun?branchName=master&jobName=macOS)](https://dev.azure.com/cloudflare-ps/wireguard-cf/_build/latest?definitionId=4&branchName=master)
-x86_64-pc-windows-msvc        |      |   ✓   |[![Build Status](https://dev.azure.com/cloudflare-ps/wireguard-cf/_apis/build/status/cloudflare.boringtun?branchName=master&jobName=Windows)](https://dev.azure.com/cloudflare-ps/wireguard-cf/_build/latest?definitionId=4&branchName=master)
-aarch64-apple-ios             |      |   ✓   |FFI bindings
-armv7-apple-ios               |      |   ✓   |FFI bindings
-armv7s-apple-ios              |      |   ✓   |FFI bindings
-aarch64-linux-android         |      |   ✓   |JNI bindings
-arm-linux-androideabi         |      |   ✓   |JNI bindings
+Target triple                 |Binary|Library|
+------------------------------|:----:|------|
+x86_64-unknown-linux-gnu      |  ✓   | ✓    |
+aarch64-unknown-linux-gnu     |  ✓   | ✓    |
+armv7-unknown-linux-gnueabihf |  ✓   | ✓    |
+x86_64-apple-darwin           |  ✓   | ✓    |
+x86_64-pc-windows-msvc        |      | ✓    |
+aarch64-apple-ios             |      | ✓    |
+armv7-apple-ios               |      | ✓    |
+armv7s-apple-ios              |      | ✓    |
+aarch64-linux-android         |      | ✓    |
+arm-linux-androideabi         |      | ✓    |
 
 <sub>Other platforms may be added in the future</sub>
 

--- a/boringtun-cli/Cargo.toml
+++ b/boringtun-cli/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "boringtun-cli"
 description = "an implementation of the WireGuard® protocol designed for portability and speed"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Noah Kennedy <nkennedy@cloudflare.com>", "Andy Grover <agrover@cloudflare.com>", "Jeff Hiner <jhiner@cloudflare.com>"]
 license = "BSD-3-Clause"
 repository = "https://github.com/cloudflare/boringtun"
-documentation = "https://docs.rs/boringtun/0.4.0/boringtun/"
+documentation = "https://docs.rs/boringtun/0.5.2/boringtun/"
 edition = "2021"
 
 [dependencies]

--- a/boringtun/Cargo.toml
+++ b/boringtun/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "boringtun"
 description = "an implementation of the WireGuard® protocol designed for portability and speed"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Noah Kennedy <nkennedy@cloudflare.com>", "Andy Grover <agrover@cloudflare.com>", "Jeff Hiner <jhiner@cloudflare.com>"]
 license = "BSD-3-Clause"
 repository = "https://github.com/cloudflare/boringtun"
-documentation = "https://docs.rs/boringtun/0.4.0/boringtun/"
+documentation = "https://docs.rs/boringtun/0.5.2/boringtun/"
 edition = "2018"
 
 [features]


### PR DESCRIPTION
# v0.5.2

### Fixed

- device: use runtime instead of compile-time environment var for macos drop privileges ([#297])

[#297]: https://github.com/cloudflare/boringtun/pull/297