### PR TITLE
chore: fix mistake in #298

### DIFF
--- a/boringtun-cli/Cargo.toml
+++ b/boringtun-cli/Cargo.toml
@@ -16,5 +16,5 @@ tracing-subscriber = "0.3.9"
 tracing-appender = "0.2.1"
 
 [dependencies.boringtun]
-version = "0.5.1"
+version = "0.5.2"
 path = "../boringtun"


### PR DESCRIPTION
I did the release with --allow-dirty and this change, so the release was fine.