### PR TITLE
Adds set_logging_function to ffi-bindings

### DIFF
--- a/boringtun/Cargo.toml
+++ b/boringtun/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 
 [features]
 jni-bindings = ["ffi-bindings", "jni"]
-ffi-bindings = []
+ffi-bindings = ["tracing-subscriber"]
 
 [dependencies]
 base64 = "0.13"
@@ -19,6 +19,7 @@ untrusted = "0.9.0"
 libc = "0.2"
 parking_lot = "0.12"
 tracing = "0.1.29"
+tracing-subscriber = { version = "0.3", features = ["fmt"], optional = true }
 ip_network = "0.4.1"
 ip_network_table = "0.2.0"
 ring = "0.16"

--- a/boringtun/src/ffi/mod.rs
+++ b/boringtun/src/ffi/mod.rs
@@ -24,7 +24,7 @@ use std::panic;
 use std::ptr;
 use std::ptr::null_mut;
 use std::slice;
-use std::sync::{Mutex, Once};
+use std::sync::Once;
 
 static PANIC_HOOK: Once = Once::new();
 
@@ -210,7 +210,7 @@ pub unsafe extern "C" fn set_logging_function(
 
     let subscriber = fmt()
         .event_format(format)
-        .with_writer(Mutex::new(writer))
+        .with_writer(std::sync::Mutex::new(writer))
         .with_max_level(tracing::Level::TRACE)
         .with_ansi(false)
         .finish();

--- a/boringtun/src/ffi/mod.rs
+++ b/boringtun/src/ffi/mod.rs
@@ -176,8 +176,10 @@ impl Write for FFIFunctionPointerWriter {
             unsafe { (self.log_func)(c_string.as_ptr()) }
             Ok(buf.len())
         } else {
-            Err(Error::new(ErrorKind::Other, "Failed to create CString from buffer."))
-
+            Err(Error::new(
+                ErrorKind::Other,
+                "Failed to create CString from buffer.",
+            ))
         }
     }
 
@@ -226,8 +228,9 @@ pub unsafe extern "C" fn set_logging_function(
             .with_writer(std::sync::Mutex::new(writer))
             .with_max_level(tracing::Level::TRACE)
             .with_ansi(false)
-            .try_init() {
-                return true
+            .try_init()
+        {
+            return true;
         }
 
         return false;

--- a/boringtun/src/ffi/mod.rs
+++ b/boringtun/src/ffi/mod.rs
@@ -223,12 +223,13 @@ pub unsafe extern "C" fn set_logging_function(
             // disable terminal escape codes
             .with_ansi(false);
 
-        if let Ok(()) = fmt()
+        if fmt()
             .event_format(format)
             .with_writer(std::sync::Mutex::new(writer))
             .with_max_level(tracing::Level::TRACE)
             .with_ansi(false)
             .try_init()
+            .is_ok()
         {
             return true;
         }

--- a/boringtun/src/ffi/mod.rs
+++ b/boringtun/src/ffi/mod.rs
@@ -12,9 +12,9 @@ use hex::encode as encode_hex;
 use libc::{raise, SIGSEGV};
 use parking_lot::Mutex;
 use rand_core::OsRng;
-use x25519_dalek::{PublicKey, StaticSecret};
 use tracing;
 use tracing_subscriber::fmt;
+use x25519_dalek::{PublicKey, StaticSecret};
 
 use crate::serialization::KeyBytes;
 use std::ffi::{CStr, CString};
@@ -173,9 +173,7 @@ impl Write for FFIFunctionPointerWriter {
     fn write(&mut self, buf: &[u8]) -> Result<usize, std::io::Error> {
         let out_str = String::from_utf8_lossy(buf).to_string();
         let c_string = CString::new(format!("{}", out_str)).unwrap();
-        unsafe {
-            (self.log_func)(c_string.as_ptr())
-        }
+        unsafe { (self.log_func)(c_string.as_ptr()) }
         Ok(buf.len())
     }
 
@@ -191,22 +189,22 @@ impl Write for FFIFunctionPointerWriter {
 /// Returns false on failure.
 #[no_mangle]
 pub unsafe extern "C" fn set_logging_function(
-    log_func: unsafe extern "C" fn(*const c_char)
+    log_func: unsafe extern "C" fn(*const c_char),
 ) -> bool {
     let writer = FFIFunctionPointerWriter { log_func };
     let format = fmt::format()
-                    // don't include levels in formatted output
-                    .with_level(false)
-                    // don't include targets
-                    .with_target(false)
-                    // don't 'include the thread ID of the current thread
-                    .with_thread_ids(false)
-                    // don't 'include the name of the current thread
-                    .with_thread_names(false)
-                    // use the `Compact` formatting style.
-                    .compact()
-                    // disable terminal escape codes
-                    .with_ansi(false);
+        // don't include levels in formatted output
+        .with_level(false)
+        // don't include targets
+        .with_target(false)
+        // don't 'include the thread ID of the current thread
+        .with_thread_ids(false)
+        // don't 'include the name of the current thread
+        .with_thread_names(false)
+        // use the `Compact` formatting style.
+        .compact()
+        // disable terminal escape codes
+        .with_ansi(false);
 
     let subscriber = fmt()
         .event_format(format)

--- a/boringtun/src/wireguard_ffi.h
+++ b/boringtun/src/wireguard_ffi.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <stdbool.h>
 
 struct wireguard_tunnel; // This corresponds to the Rust type
 
@@ -55,6 +56,14 @@ void x25519_key_to_str_free(const char *key_str);
 // Check if a null terminated string represents a valid x25519 key
 // Returns 0 if not
 int check_base64_encoded_x25519_key(const char *key);
+
+/**
+ Sets the default tracing_subscriber to write to log_func.
+ Uses Compact format without level, target, thread ids, thread names, or ansi control characters.
+ Subscribes to TRACE level events.
+ Returns false on failure.
+*/
+bool set_logging_function(void (*log_func)(const char *));
 
 // Allocate a new tunnel
 struct wireguard_tunnel *new_tunnel(const char *static_private,

--- a/boringtun/src/wireguard_ffi.h
+++ b/boringtun/src/wireguard_ffi.h
@@ -57,12 +57,20 @@ void x25519_key_to_str_free(const char *key_str);
 // Returns 0 if not
 int check_base64_encoded_x25519_key(const char *key);
 
-/**
- Sets the default tracing_subscriber to write to log_func.
- Uses Compact format without level, target, thread ids, thread names, or ansi control characters.
- Subscribes to TRACE level events.
- Returns false on failure.
-*/
+/// Sets the default tracing_subscriber to write to `log_func`.
+///
+/// Uses Compact format without level, target, thread ids, thread names, or ansi control characters.
+/// Subscribes to TRACE level events.
+///
+/// This function should only be called once as setting the default tracing_subscriber
+/// more than once will result in an error.
+///
+/// Returns false on failure.
+///
+/// # Safety
+///
+/// `c_char` will be freed by the library after calling `log_func`. If the value needs
+/// to be stored then `log_func` needs to create a copy, e.g. `strcpy`.
 bool set_logging_function(void (*log_func)(const char *));
 
 // Allocate a new tunnel


### PR DESCRIPTION
set_logging_function sets the default subscriber for tracing to a provided function pointer that can forward logs to C executables.