### PR TITLE
Use non-sequential peer indices

### DIFF
--- a/boringtun/src/device/mod.rs
+++ b/boringtun/src/device/mod.rs
@@ -46,6 +46,7 @@ use allowed_ips::AllowedIps;
 use parking_lot::Mutex;
 use peer::{AllowedIP, Peer};
 use poll::{EventPoll, EventRef, WaitResult};
+use rand_core::{OsRng, RngCore};
 use tun::{errno, errno_str, TunSocket};
 use udp::UDPSocket;
 
@@ -132,7 +133,7 @@ pub struct Device {
     peers: HashMap<x25519_dalek::PublicKey, Arc<Mutex<Peer>>>,
     peers_by_ip: AllowedIps<Arc<Mutex<Peer>>>,
     peers_by_idx: HashMap<u32, Arc<Mutex<Peer>>>,
-    next_index: u32,
+    next_index: IndexLfsr,
 
     config: DeviceConfig,
 
@@ -267,10 +268,7 @@ impl Drop for DeviceHandle {
 
 impl Device {
     fn next_index(&mut self) -> u32 {
-        let next_index = self.next_index;
-        self.next_index += 1;
-        assert!(next_index < (1 << 24), "Too many peers created");
-        next_index
+        self.next_index.next()
     }
 
     fn remove_peer(&mut self, pub_key: &x25519_dalek::PublicKey) {
@@ -822,5 +820,54 @@ impl Device {
             }),
         )?;
         Ok(())
+    }
+}
+
+/// A basic linear-feedback shift register implemented as xorshift, used to
+/// distribute peer indexes across the 24-bit address space reserved for peer
+/// identification.
+/// The purpose is to obscure the total number of peers using the system and to
+/// ensure it requires a non-trivial amount of processing power and/or samples
+/// to guess other peers' indices. Anything more ambitious than this is wasted
+/// with only 24 bits of space.
+struct IndexLfsr {
+    initial: u32,
+    lfsr: u32,
+    mask: u32,
+}
+
+impl IndexLfsr {
+    /// Generate a random 24-bit nonzero integer
+    fn random_index() -> u32 {
+        const LFSR_MAX: u32 = 0xffffff; // 24-bit seed
+        loop {
+            let i = OsRng.next_u32() & LFSR_MAX;
+            if i > 0 {
+                // LFSR seed must be non-zero
+                return i;
+            }
+        }
+    }
+
+    /// Generate the next value in the pseudorandom sequence
+    fn next(&mut self) -> u32 {
+        // 24-bit polynomial for randomness. This is arbitrarily chosen to
+        // inject bitflips into the value.
+        const LFSR_POLY: u32 = 0xd80000; // 24-bit polynomial
+        let value = self.lfsr - 1; // lfsr will never have value of 0
+        self.lfsr = (self.lfsr >> 1) ^ ((0u32.wrapping_sub(self.lfsr & 1u32)) & LFSR_POLY);
+        assert!(self.lfsr != self.initial, "Too many peers created");
+        value ^ self.mask
+    }
+}
+
+impl Default for IndexLfsr {
+    fn default() -> Self {
+        let seed = Self::random_index();
+        IndexLfsr {
+            initial: seed,
+            lfsr: seed,
+            mask: Self::random_index(),
+        }
     }
 }


### PR DESCRIPTION
Resolves #55 about as much as is possible given the design constraints
of boringtun peer handling.

boringtun is not intended to provide unlinkable sessions, particularly
given that source addresses remain constant across sessions. We can at
least obscure the details of the number of peers registered with
a server.