### PR TITLE
feat: Re-export x25519_dalek

### DIFF
--- a/boringtun/src/device/api.rs
+++ b/boringtun/src/device/api.rs
@@ -6,6 +6,7 @@ use super::drop_privileges::get_saved_ids;
 use super::{AllowedIP, Device, Error, SocketAddr};
 use crate::device::Action;
 use crate::serialization::KeyBytes;
+use crate::x25519;
 use hex::encode as encode_hex;
 use libc::*;
 use std::fs::{create_dir, remove_file};
@@ -224,7 +225,7 @@ fn api_set(reader: &mut BufReader<&UnixStream>, d: &mut LockReadGuard<Device>) -
                     match key {
                         "private_key" => match val.parse::<KeyBytes>() {
                             Ok(key_bytes) => {
-                                device.set_key(x25519_dalek::StaticSecret::from(key_bytes.0))
+                                device.set_key(x25519::StaticSecret::from(key_bytes.0))
                             }
                             Err(_) => return EINVAL,
                         },
@@ -253,7 +254,7 @@ fn api_set(reader: &mut BufReader<&UnixStream>, d: &mut LockReadGuard<Device>) -
                                 return api_set_peer(
                                     reader,
                                     device,
-                                    x25519_dalek::PublicKey::from(key_bytes.0),
+                                    x25519::PublicKey::from(key_bytes.0),
                                 )
                             }
                             Err(_) => return EINVAL,
@@ -273,7 +274,7 @@ fn api_set(reader: &mut BufReader<&UnixStream>, d: &mut LockReadGuard<Device>) -
 fn api_set_peer(
     reader: &mut BufReader<&UnixStream>,
     d: &mut Device,
-    pub_key: x25519_dalek::PublicKey,
+    pub_key: x25519::PublicKey,
 ) -> i32 {
     let mut cmd = String::new();
 

--- a/boringtun/src/device/integration_tests/mod.rs
+++ b/boringtun/src/device/integration_tests/mod.rs
@@ -6,6 +6,7 @@
 #[cfg(all(test, not(target_os = "macos")))]
 mod tests {
     use crate::device::{DeviceConfig, DeviceHandle};
+    use crate::x25519::{PublicKey, StaticSecret};
     use base64::encode as base64encode;
     use hex::encode;
     use rand_core::OsRng;
@@ -18,7 +19,6 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
     use std::thread;
-    use x25519_dalek::{PublicKey, StaticSecret};
 
     static NEXT_IFACE_IDX: AtomicUsize = AtomicUsize::new(100); // utun 100+ should be vacant during testing on CI
     static NEXT_PORT: AtomicUsize = AtomicUsize::new(61111); // Use ports starting with 61111, hoping we don't run into a taken port 🤷

--- a/boringtun/src/ffi/mod.rs
+++ b/boringtun/src/ffi/mod.rs
@@ -7,6 +7,7 @@
 
 //! C bindings for the BoringTun library
 use super::noise::{Tunn, TunnResult};
+use crate::x25519::{PublicKey, StaticSecret};
 use base64::{decode, encode};
 use hex::encode as encode_hex;
 use libc::{raise, SIGSEGV};
@@ -14,7 +15,6 @@ use parking_lot::Mutex;
 use rand_core::OsRng;
 use tracing;
 use tracing_subscriber::fmt;
-use x25519_dalek::{PublicKey, StaticSecret};
 
 use crate::serialization::KeyBytes;
 use std::ffi::{CStr, CString};

--- a/boringtun/src/lib.rs
+++ b/boringtun/src/lib.rs
@@ -18,3 +18,10 @@ pub mod noise;
 pub(crate) mod sleepyinstant;
 
 pub(crate) mod serialization;
+
+/// Re-export of the x25519 types
+pub mod x25519 {
+    pub use x25519_dalek::{
+        EphemeralSecret, PublicKey, ReusableSecret, SharedSecret, StaticSecret,
+    };
+}

--- a/boringtun/src/noise/mod.rs
+++ b/boringtun/src/noise/mod.rs
@@ -12,6 +12,7 @@ use crate::noise::errors::WireGuardError;
 use crate::noise::handshake::Handshake;
 use crate::noise::rate_limiter::RateLimiter;
 use crate::noise::timers::{TimerName, Timers};
+use crate::x25519;
 
 use std::collections::VecDeque;
 use std::convert::{TryFrom, TryInto};
@@ -191,14 +192,14 @@ impl Tunn {
 
     /// Create a new tunnel using own private key and the peer public key
     pub fn new(
-        static_private: x25519_dalek::StaticSecret,
-        peer_static_public: x25519_dalek::PublicKey,
+        static_private: x25519::StaticSecret,
+        peer_static_public: x25519::PublicKey,
         preshared_key: Option<[u8; 32]>,
         persistent_keepalive: Option<u16>,
         index: u32,
         rate_limiter: Option<Arc<RateLimiter>>,
     ) -> Result<Self, &'static str> {
-        let static_public = x25519_dalek::PublicKey::from(&static_private);
+        let static_public = x25519::PublicKey::from(&static_private);
 
         let tunn = Tunn {
             handshake: Handshake::new(
@@ -228,8 +229,8 @@ impl Tunn {
     /// Update the private key and clear existing sessions
     pub fn set_static_private(
         &mut self,
-        static_private: x25519_dalek::StaticSecret,
-        static_public: x25519_dalek::PublicKey,
+        static_private: x25519::StaticSecret,
+        static_public: x25519::PublicKey,
         rate_limiter: Option<Arc<RateLimiter>>,
     ) -> Result<(), WireGuardError> {
         self.timers.should_reset_rr = rate_limiter.is_none();

--- a/boringtun/src/noise/rate_limiter.rs
+++ b/boringtun/src/noise/rate_limiter.rs
@@ -52,7 +52,7 @@ pub struct RateLimiter {
 }
 
 impl RateLimiter {
-    pub fn new(public_key: &x25519_dalek::PublicKey, limit: u64) -> Self {
+    pub fn new(public_key: &crate::x25519::PublicKey, limit: u64) -> Self {
         let mut secret_key = [0u8; 16];
         OsRng.fill_bytes(&mut secret_key);
         RateLimiter {


### PR DESCRIPTION
This way downstream crates not have to explicitly import the
x25519_dalek crate and sync it up when needed.