### PR TITLE
Fix warning of unused Box::from_raw() return value.

### DIFF
--- a/boringtun/src/ffi/mod.rs
+++ b/boringtun/src/ffi/mod.rs
@@ -134,7 +134,7 @@ pub extern "C" fn x25519_key_to_hex(key: x25519_key) -> *const c_char {
 /// Frees memory of the string given by `x25519_key_to_hex` or `x25519_key_to_base64`
 #[no_mangle]
 pub unsafe extern "C" fn x25519_key_to_str_free(stringified_key: *mut c_char) {
-    let _ = CString::from_raw(stringified_key);
+    drop(CString::from_raw(stringified_key));
 }
 
 /// Check if the input C-string represents a valid base64 encoded x25519 key.
@@ -322,7 +322,7 @@ pub unsafe extern "C" fn new_tunnel(
 /// Drops the Tunn object
 #[no_mangle]
 pub unsafe extern "C" fn tunnel_free(tunnel: *mut Mutex<Tunn>) {
-    Box::from_raw(tunnel);
+    drop(Box::from_raw(tunnel));
 }
 
 /// Write an IP packet from the tunnel interface.


### PR DESCRIPTION
I used the `drop()` function, as the compiler warning message suggests. I also noticed that a similar issue was previously fixed in this file by using `let _ =` syntax, so I also changed that to use `drop()` for consistency and because I think `drop()` is more readable.