### PR TITLE
Add different error type for a duplicate counter

### DIFF
--- a/boringtun/src/noise/errors.rs
+++ b/boringtun/src/noise/errors.rs
@@ -14,6 +14,7 @@ pub enum WireGuardError {
     InvalidMac,
     InvalidAeadTag,
     InvalidCounter,
+    DuplicateCounter,
     InvalidPacket,
     NoCurrentSession,
     LockFailed,


### PR DESCRIPTION
This allows those who are debugging to more easily understand if an error from boringtun is a result of a duplicate packet or an actual issue with a invalid counter