### PR TITLE
allow timestamps to be equal

### DIFF
--- a/boringtun/src/noise/handshake.rs
+++ b/boringtun/src/noise/handshake.rs
@@ -157,7 +157,7 @@ fn aead_chacha20_open_inner<'in_out>(
     Ok(())
 }
 
-#[derive(Debug)]
+#[derive(Debug, Ord, PartialOrd, Eq, PartialEq)]
 /// This struct represents a 12 byte [Tai64N](https://cr.yp.to/libtai/tai64.html) timestamp
 struct Tai64N {
     secs: u64,
@@ -218,12 +218,6 @@ impl Tai64N {
         //}
 
         Ok(Tai64N { secs, nano })
-    }
-
-    /// Check if this timestamp represents a time that is chronologically after the time represented
-    /// by the other timestamp
-    pub fn after(&self, other: &Tai64N) -> bool {
-        (self.secs > other.secs) || ((self.secs == other.secs) && (self.nano > other.nano))
     }
 }
 
@@ -540,7 +534,7 @@ impl Handshake {
         aead_chacha20_open(&mut timestamp, &key, 0, packet.encrypted_timestamp, &hash)?;
 
         let timestamp = Tai64N::parse(&timestamp)?;
-        if !timestamp.after(&self.last_handshake_timestamp) {
+        if timestamp < self.last_handshake_timestamp {
             // Possibly a replay
             return Err(WireGuardError::WrongTai64nTimestamp);
         }


### PR DESCRIPTION
on a local machine there is no latency and timestamps will often be exactly the same as containers communicate with each other.