### PR TITLE
Clarify that CAP_NET_ADMIN is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ arm-linux-androideabi         |      | ✓    |
 
 `x86-64`, `aarch64` and `armv7` architectures are supported. The behaviour should be identical to that of [wireguard-go](https://git.zx2c4.com/wireguard-go/about/), with the following difference:
 
-`boringtun` will drop privileges when started. When privileges are dropped it is not possible to set `fwmark`. If `fwmark` is required, such as when using `wg-quick`, instead running with `sudo`, give the executable the `CAP_NET_ADMIN` capability using: `sudo setcap cap_net_admin+epi boringtun`. Alternatively run with `--disable-drop-privileges` or set the environment variable `WG_SUDO=1`.
+`boringtun` will drop privileges when started. When privileges are dropped it is not possible to set `fwmark`. If `fwmark` is required, such as when using `wg-quick`, run with `--disable-drop-privileges` or set the environment variable `WG_SUDO=1`.
+
+You will need to give the executable the `CAP_NET_ADMIN` capability using: `sudo setcap cap_net_admin+epi boringtun`. sudo is not needed.
 
 #### macOS
 


### PR DESCRIPTION
From the current wording of the README, I thought boringtun could run without `CAP_NET_ADMIN`- but it can't at all, failing with:

```
2023-01-04T23:37:51.496375Z ERROR boringtun_cli: Failed to initialize tunnel, error: IOCtl("Operation not permitted")
```

It looks like this originates from `ioctl(fd, TUNSETIFF as _, &ifr)`, which is a privileged operation. 

I think I'm not the only one to make this mistake (https://github.com/cloudflare/boringtun/issues/117), so this clarifies that `CAP_NET_ADMIN` is required.