### PR TITLE
Add RateLimiter functions to the C FFI

### DIFF
--- a/boringtun/src/ffi/mod.rs
+++ b/boringtun/src/ffi/mod.rs
@@ -517,3 +517,14 @@ pub unsafe extern "C" fn wireguard_verify_packet(
         },
     }
 }
+
+/// Reset the wireguard packet count
+#[no_mangle]
+pub unsafe extern "C" fn wireguard_reset_count(
+    rate_limiter: *const Mutex<RateLimiter>,
+) {
+    // Lock the rate limiter from other use
+    let rate_limiter = rate_limiter.as_ref().unwrap().lock();
+
+    rate_limiter.reset_count();
+}

--- a/boringtun/src/wireguard_ffi.h
+++ b/boringtun/src/wireguard_ffi.h
@@ -7,6 +7,7 @@
 #include <stdbool.h>
 
 struct wireguard_tunnel; // This corresponds to the Rust type
+struct wireguard_rate_limiter; // This corresponds to the Rust type
 
 enum
 {
@@ -104,3 +105,7 @@ struct wireguard_result wireguard_force_handshake(const struct wireguard_tunnel 
                                                   uint32_t dst_size);
 
 struct stats wireguard_stats(const struct wireguard_tunnel *tunnel);
+
+// Allocate a rate limiter
+struct wireguard_rate_limiter *new_rate_limiter(const char *server_static_public,
+                                                uint64_t limit);     // The 24bit index prefix to be used for session indexes

--- a/boringtun/src/wireguard_ffi.h
+++ b/boringtun/src/wireguard_ffi.h
@@ -29,6 +29,12 @@ struct wireguard_result
     size_t size;
 };
 
+struct wireguard_verify_result
+{
+    wireguard_result result;
+    int32_t idx; // idx (-1 if not available)
+};
+
 struct stats
 {
     int64_t time_since_last_handshake;
@@ -108,4 +114,15 @@ struct stats wireguard_stats(const struct wireguard_tunnel *tunnel);
 
 // Allocate a rate limiter
 struct wireguard_rate_limiter *new_rate_limiter(const char *server_static_public,
-                                                uint64_t limit);     // The 24bit index prefix to be used for session indexes
+                                                uint64_t limit);
+
+// Deallocate the rate limiter
+void rate_limiter_free(struct wireguard_rate_limiter *);
+
+// Verify a packet.
+// May produce a packet to request a cookie from the peer
+struct wireguard_verify_result wireguard_verify_packet(const struct wireguard_rate_limiter *rate_limiter,
+                                                       const uint8_t *src,
+                                                       uint32_t src_size,
+                                                       uint8_t *dst,
+                                                       uint32_t dst_size);

--- a/boringtun/src/wireguard_ffi.h
+++ b/boringtun/src/wireguard_ffi.h
@@ -126,3 +126,6 @@ struct wireguard_verify_result wireguard_verify_packet(const struct wireguard_ra
                                                        uint32_t src_size,
                                                        uint8_t *dst,
                                                        uint32_t dst_size);
+
+// Reset the wireguard rate limiter
+void wireguard_reset_count(struct wireguard_rate_limiter *);


### PR DESCRIPTION
Adds the RateLimiter functions to the C FFI.

Note that I am still relatively new to the Rust language so any advice on how to make the code in this PR would be appreciated. 