### PR TITLE
Reduce dst buffer requirement for receive_packet_data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,7 +97,7 @@ dependencies = [
  "ring",
  "tracing",
  "tracing-subscriber",
- "untrusted 0.9.0",
+ "untrusted",
  "x25519-dalek",
 ]
 
@@ -466,9 +466,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
@@ -819,7 +819,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom 0.2.7",
+ "getrandom 0.2.8",
 ]
 
 [[package]]
@@ -878,16 +878,14 @@ checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+version = "0.17.0-not-released-yet"
+source = "git+https://github.com/briansmith/ring.git?rev=450ada288f1805795140097ec96396b890bcf722#450ada288f1805795140097ec96396b890bcf722"
 dependencies = [
  "cc",
+ "getrandom 0.2.8",
  "libc",
- "once_cell",
  "spin",
- "untrusted 0.7.1",
- "web-sys",
+ "untrusted",
  "winapi",
 ]
 
@@ -982,9 +980,9 @@ checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
 name = "spin"
-version = "0.5.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
 
 [[package]]
 name = "strsim"
@@ -1197,12 +1195,6 @@ dependencies = [
  "generic-array",
  "subtle",
 ]
-
-[[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"

--- a/boringtun/Cargo.toml
+++ b/boringtun/Cargo.toml
@@ -24,7 +24,7 @@ tracing = "0.1.29"
 tracing-subscriber = { version = "0.3", features = ["fmt"], optional = true }
 ip_network = "0.4.1"
 ip_network_table = "0.2.0"
-ring = "0.16"
+ring = { git = "https://github.com/briansmith/ring.git", rev = "450ada288f1805795140097ec96396b890bcf722" }
 x25519-dalek = { version = "2.0.0-pre.1", features = ["reusable_secrets"] }
 rand_core = { version = "0.6.3", features = ["getrandom"] }
 chacha20poly1305 = "0.10.0-pre.1"

--- a/boringtun/benches/crypto_benches/x25519_shared_key_benching.rs
+++ b/boringtun/benches/crypto_benches/x25519_shared_key_benching.rs
@@ -36,12 +36,9 @@ pub fn bench_x25519_shared_key(c: &mut Criterion) {
                     .unwrap()
             },
             |my_private_key| {
-                ring::agreement::agree_ephemeral(
-                    my_private_key,
-                    &my_public_key,
-                    ring::error::Unspecified,
-                    |_key_material| Ok(()),
-                )
+                ring::agreement::agree_ephemeral(my_private_key, &my_public_key, |_key_material| {
+                    Ok::<_, ring::error::Unspecified>(())
+                })
                 .unwrap()
             },
             BatchSize::SmallInput,


### PR DESCRIPTION
There's a minor issue in `receive_packet_data` that can cause unnecessary friction when calling with a dst buffer exactly big enough to fit the decrypted packet. Specifically, the fn currently requires passing in a dst buffer capable of containing both the decrypted packet AND the 16-byte aead tag. This is problematic because wintun expects code to reserve an exact packet size lease and then commit it for writing, without providing any ability to reduce the lease commit afterwards.

So we need to use an aead open fn that can accept separate args for the in-place buffer and the aead. We can't decrypt inside the packet buffer and copy out, because the required mutability would affect a wide swath of code. The fix unfortunately requires an unreleased version of ring. The crate maintainer surprisingly hasn't released a new version in nearly two years, but is still maintaining an alpha 0.17 in git.

