### PR TITLE
ci: build & publish releases

### DIFF
--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -1,6 +1,6 @@
 name: PR Status Checks
 env:
-  RUST_VERSION: stable
+  RUST_VERSION: 1.69.0
 
 on:
   push: {}

--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -1,8 +1,9 @@
 name: PR Status Checks
+env:
+  RUST_VERSION: stable
 
 on:
-  push:
-    branches: [ "master" ]
+  push: {}
   pull_request:
     branches: [ "master" ]
 
@@ -97,3 +98,67 @@ jobs:
         with:
           toolchain: stable
       - run: cargo test -- --ignored
+
+  release:
+    needs: [tests, integration-tests]
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        binary:
+          - workspace: boringtun-cli
+            name: boringtun-cli
+        arch:
+          - amd64
+          - aarch64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Setup QEMU
+        if: matrix.arch != 'amd64'
+        run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+      - name: Setup Rust
+        run: |
+          rm -rf ~/.cargo
+          docker run -d --name=init \
+            -v $PWD/${{ matrix.binary.workspace }}:/repo/ -w /repo \
+            ghcr.io/innopals/rust-centos7:$RUST_VERSION-${{ matrix.arch }} \
+            tail -f /etc/issue
+          docker cp init:/root/.cargo ~/.cargo
+          mkdir -p ${HOME}/.local/bin
+          cd ${HOME}/.local/bin
+          echo '#!/bin/bash' > rustc
+          echo 'docker exec init rustc $@' > rustc
+          echo '#!/bin/bash' > cargo
+          echo 'docker exec init cargo $@' > cargo
+          chmod +x *
+          rustc -vV
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.binary.workspace }}/${{ matrix.binary.name }}-${{ matrix.arch }}
+          cache-on-failure: true
+          workspaces: ${{ matrix.binary.workspace }} -> target
+      - name: Start Build Container
+        run: |
+          docker run -d --name=build \
+            -v $PWD/${{ matrix.binary.workspace }}:/repo/ -v $HOME/.cargo:/root/.cargo -w /repo \
+            ghcr.io/innopals/rust-centos7:$RUST_VERSION-${{ matrix.arch }} \
+            tail -f /etc/issue
+      - name: Build Artifacts
+        run: |
+          docker exec build bash -c 'set -e
+            cargo build --release
+            strip target/release/${{ matrix.binary.name }}
+            cp target/release/${{ matrix.binary.name }} target/release/${{ matrix.binary.name }}-${{ matrix.arch }}
+          '
+          sudo chown -R runner:docker ${{ matrix.binary.workspace }}/target
+          sudo chown -R runner:docker $HOME/.cargo
+      - name: publish artifacts
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+            files: |
+              ${{ matrix.binary.workspace }}/target/release/${{ matrix.binary.name }}-${{ matrix.arch }}

--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -101,7 +101,7 @@ jobs:
 
   release:
     # needs: [tests, integration-tests]
-    if: startsWith(github.ref, 'refs/tags/')
+    # if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -127,8 +127,10 @@ jobs:
             -v $PWD/${{ matrix.binary.workspace }}:/repo/ -w /repo \
             ghcr.io/innopals/rust-centos7:$RUST_VERSION-${{ matrix.arch }} \
             tail -f /etc/issue
+          # Initial cargo installation to be cached
           docker cp init:/root/.cargo ~/.cargo
           mkdir -p ${HOME}/.local/bin
+          # Use cargo & rustc in the container to obtain rust version and to clean up artifacts
           cd ${HOME}/.local/bin
           echo '#!/bin/bash' > rustc
           echo 'docker exec init rustc $@' > rustc
@@ -154,11 +156,22 @@ jobs:
             strip target/release/${{ matrix.binary.name }}
             cp target/release/${{ matrix.binary.name }} target/release/${{ matrix.binary.name }}-${{ matrix.arch }}
           '
+      - name: Amend File Permissions
+        run: |
           sudo chown -R runner:docker ${{ matrix.binary.workspace }}/target
           sudo chown -R runner:docker $HOME/.cargo
-      - name: publish artifacts
+      - name: Publish Artifacts
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1
         with:
+            files: |
+              ${{ matrix.binary.workspace }}/target/release/${{ matrix.binary.name }}-${{ matrix.arch }}
+      - name: Draft Artifacts
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+        uses: softprops/action-gh-release@v1
+        with:
+            draft: true
+            name: "latest"
+            tag_name: "latest"
             files: |
               ${{ matrix.binary.workspace }}/target/release/${{ matrix.binary.name }}-${{ matrix.arch }}

--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -6,6 +6,7 @@ env:
 on:
   push:
     branches: [ "master" ]
+    tags: ['*']
   pull_request:
     branches: [ "master" ]
 

--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -100,14 +100,14 @@ jobs:
       - run: cargo test -- --ignored
 
   release:
-    needs: [tests, integration-tests]
+    # needs: [tests, integration-tests]
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
         binary:
-          - workspace: boringtun-cli
+          - workspace: .
             name: boringtun-cli
         arch:
           - amd64
@@ -150,7 +150,7 @@ jobs:
       - name: Build Artifacts
         run: |
           docker exec build bash -c 'set -e
-            cargo build --release
+            cargo build --release --bin=${{ matrix.binary.name }}
             strip target/release/${{ matrix.binary.name }}
             cp target/release/${{ matrix.binary.name }} target/release/${{ matrix.binary.name }}-${{ matrix.arch }}
           '

--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -1,9 +1,11 @@
 name: PR Status Checks
 env:
+  # https://github.com/rust-lang/rust/issues/113104
   RUST_VERSION: 1.69.0
 
 on:
-  push: {}
+  push:
+    branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
 
@@ -100,8 +102,7 @@ jobs:
       - run: cargo test -- --ignored
 
   release:
-    # needs: [tests, integration-tests]
-    # if: startsWith(github.ref, 'refs/tags/')
+    needs: [tests, integration-tests]
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false


### PR DESCRIPTION
Build and publish boringtun-cli binary for linux to GitHub releases.

- Cross build with https://github.com/innopals/rust-centos7 and link with glibc 2.17, in order to make it compatible with most Linux distributions
- Use rust 1.69.0 to temporarily get around with https://github.com/rust-lang/rust/issues/113104
- Use https://github.com/Swatinem/rust-cache to reuse and speed up builds

Example runs:

- Draft build: https://github.com/bestmike007/boringtun/actions/runs/5922106517
- Release build: https://github.com/bestmike007/boringtun/actions/runs/5922343776/attempts/1
- Release build w/ cache: https://github.com/bestmike007/boringtun/actions/runs/5922343776/job/16057203843