### PR TITLE
build: Add apple tvOS support

### DIFF
--- a/boringtun-cli/src/main.rs
+++ b/boringtun-cli/src/main.rs
@@ -11,7 +11,7 @@ use std::process::exit;
 use tracing::Level;
 
 fn check_tun_name(_v: String) -> Result<(), String> {
-    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
     {
         if boringtun::device::tun::parse_utun_name(&_v).is_ok() {
             Ok(())

--- a/boringtun/src/device/mod.rs
+++ b/boringtun/src/device/mod.rs
@@ -9,7 +9,7 @@ pub mod drop_privileges;
 mod integration_tests;
 pub mod peer;
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
 #[path = "kqueue.rs"]
 pub mod poll;
 
@@ -17,7 +17,7 @@ pub mod poll;
 #[path = "epoll.rs"]
 pub mod poll;
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
 #[path = "tun_darwin.rs"]
 pub mod tun;
 
@@ -75,7 +75,7 @@ pub enum Error {
     SetSockOpt(String),
     #[error("Invalid tunnel name")]
     InvalidTunnelName,
-    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
     #[error("{0}")]
     GetSockOpt(io::Error),
     #[error("{0}")]

--- a/boringtun/src/sleepyinstant/unix.rs
+++ b/boringtun/src/sleepyinstant/unix.rs
@@ -3,9 +3,9 @@ use std::time::Duration;
 use nix::sys::time::TimeSpec;
 use nix::time::{clock_gettime, ClockId};
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
 const CLOCK_ID: ClockId = ClockId::CLOCK_MONOTONIC;
-#[cfg(not(any(target_os = "macos", target_os = "ios")))]
+#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
 const CLOCK_ID: ClockId = ClockId::CLOCK_BOOTTIME;
 
 #[derive(Clone, Copy, Debug)]


### PR DESCRIPTION
This PR allows using boringtun lib to target [tier 3 *-apple builds](https://doc.rust-lang.org/nightly/rustc/platform-support/apple-tvos.html):

- Apple tvOS on aarch64
- Apple tvOS Simulator on x86_64