### PR TITLE
ci: add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: weekly


### PR DESCRIPTION
Proactively bumping dependencies keeps the ecosystem in sync. See https://github.com/cloudflare/boringtun/pull/367.