### PR TITLE
feat: output private key for get command

### DIFF
--- a/boringtun/src/device/api.rs
+++ b/boringtun/src/device/api.rs
@@ -157,6 +157,8 @@ impl Device {
 fn api_get(writer: &mut BufWriter<&UnixStream>, d: &Device) -> i32 {
     // get command requires an empty line, but there is no reason to be religious about it
     if let Some(ref k) = d.key_pair {
+        writeln!(writer, "private_key={}", encode_hex(k.0.as_bytes()));
+        // Is this even needed? This seems like a custom extension in boringtun
         writeln!(writer, "own_public_key={}", encode_hex(k.1.as_bytes()));
     }
 


### PR DESCRIPTION
PR adds the output for `private_key` when the `get=1` command is used.

This allows the `wg show` command to properly show the public key in the output, which is useful if you have multiple wireguard devices or if you perform some automation around your wireguard devices based on the public key.

Example without:

```
; sudo wg show
interface: wg0
  listening port: 39742
```

Example with:

```
interface: wg0
  public key: XXXX/XXXXXXXXXXXXXXXXXX/XXXXXXXXXXXXXXX
  private key: (hidden)
  listening port: 37019
```

Additionally, added a comment around the `own_public_key` part, not entirely sure what the use for that is. Perhaps some boringtun extension?