### PR TITLE
Add (partial) support for NetBSD

### DIFF
--- a/boringtun/src/sleepyinstant/unix.rs
+++ b/boringtun/src/sleepyinstant/unix.rs
@@ -3,9 +3,9 @@ use std::time::Duration;
 use nix::sys::time::TimeSpec;
 use nix::time::{clock_gettime, ClockId};
 
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "netbsd"))]
 const CLOCK_ID: ClockId = ClockId::CLOCK_MONOTONIC;
-#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
+#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "netbsd")))]
 const CLOCK_ID: ClockId = ClockId::CLOCK_BOOTTIME;
 
 #[derive(Clone, Copy, Debug)]


### PR DESCRIPTION
NetBSD does not have any `CLOCK_BOOTTIME`, treat it like macOS/iOS/tvOS (or probably, more likely, anything that is not Android nor Linux!).

---

**NOTE**: On NetBSD is still not possible to do `cargo build --lib --no-default-features --release` because there are also several tun bits that are missing. However, as is, this change improve a little the status and is needed for possible boringtun users (that I think do not needs any tun bits) like [mitmproxy_rs](https://github.com/mitmproxy/mitmproxy_rs).
