### PR TITLE
WIP refactor: de-couple from `Instant::now`

### DIFF
--- a/boringtun/src/device/mod.rs
+++ b/boringtun/src/device/mod.rs
@@ -679,7 +679,8 @@ impl Device {
                     if flush {
                         // Flush pending queue
                         while let TunnResult::WriteToNetwork(packet) =
-                            p.tunnel.decapsulate(None, &[], &mut t.dst_buf[..])
+                            p.tunnel
+                                .decapsulate(None, &[], &mut t.dst_buf[..], Instant::now())
                         {
                             let _: Result<_, _> = udp.send_to(packet, &addr);
                         }
@@ -734,6 +735,7 @@ impl Device {
                         Some(peer_addr),
                         &t.src_buf[..read_bytes],
                         &mut t.dst_buf[..],
+                        Instant::now(),
                     ) {
                         TunnResult::Done => {}
                         TunnResult::Err(e) => eprintln!("Decapsulate error {:?}", e),
@@ -756,7 +758,8 @@ impl Device {
                     if flush {
                         // Flush pending queue
                         while let TunnResult::WriteToNetwork(packet) =
-                            p.tunnel.decapsulate(None, &[], &mut t.dst_buf[..])
+                            p.tunnel
+                                .decapsulate(None, &[], &mut t.dst_buf[..], Instant::now())
                         {
                             let _: Result<_, _> = udp.send(packet);
                         }
@@ -816,7 +819,10 @@ impl Device {
                         None => continue,
                     };
 
-                    match peer.tunnel.encapsulate(src, &mut t.dst_buf[..]) {
+                    match peer
+                        .tunnel
+                        .encapsulate(src, &mut t.dst_buf[..], Instant::now())
+                    {
                         TunnResult::Done => {}
                         TunnResult::Err(e) => {
                             tracing::error!(message = "Encapsulate error", error = ?e)

--- a/boringtun/src/device/peer.rs
+++ b/boringtun/src/device/peer.rs
@@ -9,6 +9,7 @@ use std::str::FromStr;
 
 use crate::device::{AllowedIps, Error};
 use crate::noise::{Tunn, TunnResult};
+use std::time::Instant;
 
 #[derive(Default, Debug)]
 pub struct Endpoint {
@@ -71,7 +72,7 @@ impl Peer {
     }
 
     pub fn update_timers<'a>(&mut self, dst: &'a mut [u8]) -> TunnResult<'a> {
-        self.tunnel.update_timers(dst)
+        self.tunnel.update_timers(Instant::now(), dst)
     }
 
     pub fn endpoint(&self) -> parking_lot::RwLockReadGuard<'_, Endpoint> {

--- a/boringtun/src/noise/mod.rs
+++ b/boringtun/src/noise/mod.rs
@@ -18,7 +18,7 @@ use std::collections::VecDeque;
 use std::convert::{TryFrom, TryInto};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 /// The default value to use for rate limiting, when no other rate limiter is defined
 const PEER_HANDSHAKE_RATE_LIMIT: u64 = 10;
@@ -198,6 +198,8 @@ impl Tunn {
         persistent_keepalive: Option<u16>,
         index: u32,
         rate_limiter: Option<Arc<RateLimiter>>,
+        now: Instant,
+        unix_now: u64,
     ) -> Self {
         let static_public = x25519::PublicKey::from(&static_private);
 
@@ -208,6 +210,8 @@ impl Tunn {
                 peer_static_public,
                 index << 8,
                 preshared_key,
+                now,
+                unix_now,
             ),
             sessions: Default::default(),
             current: Default::default(),
@@ -215,10 +219,14 @@ impl Tunn {
             rx_bytes: Default::default(),
 
             packet_queue: VecDeque::new(),
-            timers: Timers::new(persistent_keepalive, rate_limiter.is_none()),
+            timers: Timers::new(persistent_keepalive, rate_limiter.is_none(), now),
 
             rate_limiter: rate_limiter.unwrap_or_else(|| {
-                Arc::new(RateLimiter::new(&static_public, PEER_HANDSHAKE_RATE_LIMIT))
+                Arc::new(RateLimiter::new(
+                    &static_public,
+                    PEER_HANDSHAKE_RATE_LIMIT,
+                    now,
+                ))
             }),
         }
     }
@@ -232,7 +240,11 @@ impl Tunn {
     ) {
         self.timers.should_reset_rr = rate_limiter.is_none();
         self.rate_limiter = rate_limiter.unwrap_or_else(|| {
-            Arc::new(RateLimiter::new(&static_public, PEER_HANDSHAKE_RATE_LIMIT))
+            Arc::new(RateLimiter::new(
+                &static_public,
+                PEER_HANDSHAKE_RATE_LIMIT,
+                self.timers.now,
+            ))
         });
         self.handshake
             .set_static_private(static_private, static_public);
@@ -351,7 +363,9 @@ impl Tunn {
             remote_idx = p.sender_idx
         );
 
-        let session = self.handshake.receive_handshake_response(p)?;
+        let session = self
+            .handshake
+            .receive_handshake_response(p, self.timers.now)?;
 
         let keepalive_packet = session.format_packet_data(&[], dst);
         // Store new session in ring buffer
@@ -445,7 +459,10 @@ impl Tunn {
 
         let starting_new_handshake = !self.handshake.is_in_progress();
 
-        match self.handshake.format_handshake_initiation(dst) {
+        match self
+            .handshake
+            .format_handshake_initiation(dst, self.timers.now)
+        {
             Ok(packet) => {
                 tracing::debug!("Sending handshake_initiation");
 
@@ -593,7 +610,7 @@ mod tests {
     use super::*;
     use rand_core::{OsRng, RngCore};
 
-    fn create_two_tuns() -> (Tunn, Tunn) {
+    fn create_two_tuns(now: Instant) -> (Tunn, Tunn) {
         let my_secret_key = x25519_dalek::StaticSecret::random_from_rng(OsRng);
         let my_public_key = x25519_dalek::PublicKey::from(&my_secret_key);
         let my_idx = OsRng.next_u32();
@@ -602,9 +619,27 @@ mod tests {
         let their_public_key = x25519_dalek::PublicKey::from(&their_secret_key);
         let their_idx = OsRng.next_u32();
 
-        let my_tun = Tunn::new(my_secret_key, their_public_key, None, None, my_idx, None);
+        let my_tun = Tunn::new(
+            my_secret_key,
+            their_public_key,
+            None,
+            None,
+            my_idx,
+            None,
+            now,
+            0,
+        );
 
-        let their_tun = Tunn::new(their_secret_key, my_public_key, None, None, their_idx, None);
+        let their_tun = Tunn::new(
+            their_secret_key,
+            my_public_key,
+            None,
+            None,
+            their_idx,
+            None,
+            now,
+            0,
+        );
 
         (my_tun, their_tun)
     }
@@ -656,8 +691,8 @@ mod tests {
         assert!(matches!(keepalive, TunnResult::Done));
     }
 
-    fn create_two_tuns_and_handshake() -> (Tunn, Tunn) {
-        let (mut my_tun, mut their_tun) = create_two_tuns();
+    fn create_two_tuns_and_handshake(now: Instant) -> (Tunn, Tunn) {
+        let (mut my_tun, mut their_tun) = create_two_tuns(now);
         let init = create_handshake_init(&mut my_tun);
         let resp = create_handshake_response(&mut their_tun, &init);
         let keepalive = parse_handshake_resp(&mut my_tun, &resp);
@@ -691,12 +726,12 @@ mod tests {
 
     #[test]
     fn create_two_tunnels_linked_to_eachother() {
-        let (_my_tun, _their_tun) = create_two_tuns();
+        let (_my_tun, _their_tun) = create_two_tuns(Instant::now());
     }
 
     #[test]
     fn handshake_init() {
-        let (mut my_tun, _their_tun) = create_two_tuns();
+        let (mut my_tun, _their_tun) = create_two_tuns(Instant::now());
         let init = create_handshake_init(&mut my_tun);
         let packet = Tunn::parse_incoming_packet(&init).unwrap();
         assert!(matches!(packet, Packet::HandshakeInit(_)));
@@ -704,7 +739,7 @@ mod tests {
 
     #[test]
     fn handshake_init_and_response() {
-        let (mut my_tun, mut their_tun) = create_two_tuns();
+        let (mut my_tun, mut their_tun) = create_two_tuns(Instant::now());
         let init = create_handshake_init(&mut my_tun);
         let resp = create_handshake_response(&mut their_tun, &init);
         let packet = Tunn::parse_incoming_packet(&resp).unwrap();
@@ -713,7 +748,7 @@ mod tests {
 
     #[test]
     fn full_handshake() {
-        let (mut my_tun, mut their_tun) = create_two_tuns();
+        let (mut my_tun, mut their_tun) = create_two_tuns(Instant::now());
         let init = create_handshake_init(&mut my_tun);
         let resp = create_handshake_response(&mut their_tun, &init);
         let keepalive = parse_handshake_resp(&mut my_tun, &resp);
@@ -723,10 +758,18 @@ mod tests {
 
     #[test]
     fn full_handshake_plus_timers() {
-        let (mut my_tun, mut their_tun) = create_two_tuns_and_handshake();
+        let now = Instant::now();
+
+        let (mut my_tun, mut their_tun) = create_two_tuns_and_handshake(now);
         // Time has not yet advanced so their is nothing to do
-        assert!(matches!(my_tun.update_timers(&mut []), TunnResult::Done));
-        assert!(matches!(their_tun.update_timers(&mut []), TunnResult::Done));
+        assert!(matches!(
+            my_tun.update_timers(now, &mut []),
+            TunnResult::Done
+        ));
+        assert!(matches!(
+            their_tun.update_timers(now, &mut []),
+            TunnResult::Done
+        ));
     }
 
     #[test]
@@ -756,7 +799,7 @@ mod tests {
     #[test]
     #[cfg(feature = "mock-instant")]
     fn handshake_no_resp_rekey_timeout() {
-        let (mut my_tun, _their_tun) = create_two_tuns();
+        let (mut my_tun, _their_tun) = create_two_tuns(Instant::now());
 
         let init = create_handshake_init(&mut my_tun);
         let packet = Tunn::parse_incoming_packet(&init).unwrap();
@@ -768,7 +811,9 @@ mod tests {
 
     #[test]
     fn one_ip_packet() {
-        let (mut my_tun, mut their_tun) = create_two_tuns_and_handshake();
+        let now = Instant::now();
+
+        let (mut my_tun, mut their_tun) = create_two_tuns_and_handshake(now);
         let mut my_dst = [0u8; 1024];
         let mut their_dst = [0u8; 1024];
 

--- a/boringtun/src/noise/timers.rs
+++ b/boringtun/src/noise/timers.rs
@@ -7,12 +7,7 @@ use std::mem;
 use std::ops::{Index, IndexMut};
 
 use std::time::Duration;
-
-#[cfg(feature = "mock-instant")]
-use mock_instant::Instant;
-
-#[cfg(not(feature = "mock-instant"))]
-use crate::sleepyinstant::Instant;
+use std::time::Instant;
 
 // Some constants, represent time in seconds
 // https://www.wireguard.com/papers/wireguard.pdf#page=14
@@ -63,19 +58,23 @@ pub struct Timers {
     persistent_keepalive: usize,
     /// Should this timer call reset rr function (if not a shared rr instance)
     pub(super) should_reset_rr: bool,
+
+    /// The "current" time, i.e. when the user last called `update_timers`.
+    pub(super) now: Instant,
 }
 
 impl Timers {
-    pub(super) fn new(persistent_keepalive: Option<u16>, reset_rr: bool) -> Timers {
+    pub(super) fn new(persistent_keepalive: Option<u16>, reset_rr: bool, now: Instant) -> Timers {
         Timers {
             is_initiator: false,
-            time_started: Instant::now(),
+            time_started: now,
             timers: Default::default(),
             session_timers: Default::default(),
             want_keepalive: Default::default(),
             want_handshake: Default::default(),
             persistent_keepalive: usize::from(persistent_keepalive.unwrap_or(0)),
             should_reset_rr: reset_rr,
+            now,
         }
     }
 
@@ -86,7 +85,7 @@ impl Timers {
     // We don't really clear the timers, but we set them to the current time to
     // so the reference time frame is the same
     pub(super) fn clear(&mut self) {
-        let now = Instant::now().duration_since(self.time_started);
+        let now = self.now.duration_since(self.time_started);
         for t in &mut self.timers[..] {
             *t = now;
         }
@@ -165,14 +164,14 @@ impl Tunn {
         }
     }
 
-    pub fn update_timers<'a>(&mut self, dst: &'a mut [u8]) -> TunnResult<'a> {
+    pub fn update_timers<'a>(&mut self, now: Instant, dst: &'a mut [u8]) -> TunnResult<'a> {
         let mut handshake_initiation_required = false;
         let mut keepalive_required = false;
 
-        let time = Instant::now();
+        let time = now;
 
         if self.timers.should_reset_rr {
-            self.rate_limiter.reset_count();
+            self.rate_limiter.reset_count(now);
         }
 
         // All the times are counted from tunnel initiation, for efficiency our timers are rounded
@@ -314,7 +313,7 @@ impl Tunn {
     pub fn time_since_last_handshake(&self) -> Option<Duration> {
         let current_session = self.current;
         if self.sessions[current_session % super::N_SESSIONS].is_some() {
-            let duration_since_tun_start = Instant::now().duration_since(self.timers.time_started);
+            let duration_since_tun_start = self.timers.now.duration_since(self.timers.time_started);
             let duration_since_session_established = self.timers[TimeSessionEstablished];
 
             Some(duration_since_tun_start - duration_since_session_established)

--- a/boringtun/src/noise/timers.rs
+++ b/boringtun/src/noise/timers.rs
@@ -304,7 +304,7 @@ impl Tunn {
         }
 
         if keepalive_required {
-            return self.encapsulate(&[], dst);
+            return self.encapsulate(&[], dst, time);
         }
 
         TunnResult::Done


### PR DESCRIPTION
This is a first stab at #391. I've not looked at the mock-instant now but I'd assume that this can now be deleted and the tests written in a better way.

However, I wanted to get a first draft up to see hear what people think and to get a feeling for what the API would look like. What is a bit annoying is that we need to expose both `Instant` and `unix_now` from `Tunn::new`.