### PR TITLE
fix: connected udp socket type

### DIFF
--- a/boringtun/src/device/peer.rs
+++ b/boringtun/src/device/peer.rs
@@ -117,7 +117,7 @@ impl Peer {
             .expect("Attempt to connect to undefined endpoint");
 
         let udp_conn =
-            socket2::Socket::new(Domain::for_address(addr), Type::STREAM, Some(Protocol::UDP))?;
+            socket2::Socket::new(Domain::for_address(addr), Type::DGRAM, Some(Protocol::UDP))?;
         udp_conn.set_reuse_address(true)?;
         let bind_addr = if addr.is_ipv4() {
             SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, port).into()


### PR DESCRIPTION
connected sock needs to be DGRAM

see https://github.com/cloudflare/boringtun/issues/395

this has substantial performance impact on linux