### PR TITLE
Upgrade to daemonize 0.5.0 to get rid of boxfnonce

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,12 +116,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "boxfnonce"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5988cb1d626264ac94100be357308f29ff7cbdd3b36bda27f450a4ee3f713426"
-
-[[package]]
 name = "bstr"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,11 +407,10 @@ dependencies = [
 
 [[package]]
 name = "daemonize"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70c24513e34f53b640819f0ac9f705b673fcf4006d7aab8778bee72ebfc89815"
+checksum = "ab8bfdaacb3c887a54d41bdf48d3af8873b3f5566469f8ba21b92057509f116e"
 dependencies = [
- "boxfnonce",
  "libc",
 ]
 

--- a/boringtun-cli/Cargo.toml
+++ b/boringtun-cli/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/boringtun/0.5.2/boringtun/"
 edition = "2021"
 
 [dependencies]
-daemonize = "0.4.1"
+daemonize = "0.5.0"
 clap = { version = "3.1.6", features = ["env"] }
 tracing = "0.1.40"
 tracing-subscriber = "0.3.9"

--- a/boringtun-cli/src/main.rs
+++ b/boringtun-cli/src/main.rs
@@ -4,7 +4,7 @@
 use boringtun::device::drop_privileges::drop_privileges;
 use boringtun::device::{DeviceConfig, DeviceHandle};
 use clap::{Arg, Command};
-use daemonize::Daemonize;
+use daemonize::{Daemonize, Outcome};
 use std::fs::File;
 use std::os::unix::net::UnixDatagram;
 use std::process::exit;
@@ -118,23 +118,27 @@ fn main() {
             .with_ansi(false)
             .init();
 
-        let daemonize = Daemonize::new()
-            .working_directory("/tmp")
-            .exit_action(move || {
+        let daemonize = Daemonize::new().working_directory("/tmp");
+
+        match daemonize.execute() {
+            Outcome::Parent(Ok(_)) => {
+                // In parent process, child forked ok
                 let mut b = [0u8; 1];
                 if sock2.recv(&mut b).is_ok() && b[0] == 1 {
                     println!("BoringTun started successfully");
+                    exit(0);
                 } else {
                     eprintln!("BoringTun failed to start");
                     exit(1);
-                };
-            });
-
-        match daemonize.start() {
-            Ok(_) => tracing::info!("BoringTun started successfully"),
-            Err(e) => {
-                tracing::error!(error = ?e);
+                }
+            }
+            Outcome::Parent(Err(e)) => {
+                eprintln!("BoringTun failed to start - Fork error: {}", e);
                 exit(1);
+            }
+            Outcome::Child(_) => {
+                // In child process, we'll continue below with code that is common with foreground exec
+                tracing::info!("BoringTun started");
             }
         }
     } else {


### PR DESCRIPTION
boxfnonce crate is obsolete since Rust 1.35 and cargo audit complains about it. daemonize 0.5.0 doesn't use it any longer but is incompatible with earlier version in that the exit_action() modifier is no longer supported.

Despite the lack of any hint as to how to achieve the same thing with the newer version, it seems it can be done using daemonize.execute() instead of damonize.start(), since it will allow the parent to continue execution past the fork point.