### PR TITLE
Make queue size configurable & drop oldest packets first

### DIFF
--- a/boringtun/src/device/mod.rs
+++ b/boringtun/src/device/mod.rs
@@ -334,6 +334,7 @@ impl Device {
             keepalive,
             next_index,
             None,
+            256,
         );
 
         let peer = Peer::new(tunn, next_index, endpoint, allowed_ips, preshared_key);

--- a/boringtun/src/ffi/mod.rs
+++ b/boringtun/src/ffi/mod.rs
@@ -299,6 +299,7 @@ pub unsafe extern "C" fn new_tunnel(
         keep_alive,
         index,
         None,
+        256,
     )));
 
     PANIC_HOOK.call_once(|| {

--- a/boringtun/src/noise/mod.rs
+++ b/boringtun/src/noise/mod.rs
@@ -525,9 +525,10 @@ impl Tunn {
 
     /// Push packet to the back of the queue
     fn queue_packet(&mut self, packet: &[u8]) {
-        if self.packet_queue.len() < self.max_queue_depth {
-            // Drop if too many are already in queue
-            self.packet_queue.push_back(packet.to_vec());
+        self.packet_queue.push_back(packet.to_vec());
+        if self.packet_queue.len() > self.max_queue_depth {
+            // Drop oldest packet if too many are already in queue
+            self.packet_queue.pop_front();
         }
     }
 

--- a/boringtun/src/noise/mod.rs
+++ b/boringtun/src/noise/mod.rs
@@ -533,10 +533,8 @@ impl Tunn {
 
     /// Push packet to the front of the queue
     fn requeue_packet(&mut self, packet: Vec<u8>) {
-        if self.packet_queue.len() < self.max_queue_depth {
-            // Drop if too many are already in queue
-            self.packet_queue.push_front(packet);
-        }
+        self.packet_queue.push_front(packet);
+        assert!(self.packet_queue.len() <= self.max_queue_depth);
     }
 
     fn dequeue_packet(&mut self) -> Option<Vec<u8>> {


### PR DESCRIPTION
This PR contains three commits:

1. Make the queue size configurable. In my program, the server sometime starts on-demand, and the client buffers a significant number of packets by default, which causes a bit of flooding
2. Replaces a conditional with an assertion. I'd happily revert if this desired by maintainers. This code would probably be a bit more readable if `dequeue_packet` and `requeue_packet` were inlined into their callsite, which I'd also happily contribute
3. Drop oldest packets first. I believe this is reasonable (think TCP retransmits), but I'd be happy to keep the current behaviour if wanted

Side-note: Is there a way to run only tests that don't required sudo?