### PR TITLE
build: add FreeBSD support

### DIFF
--- a/boringtun/src/sleepyinstant/unix.rs
+++ b/boringtun/src/sleepyinstant/unix.rs
@@ -3,9 +3,9 @@ use std::time::Duration;
 use nix::sys::time::TimeSpec;
 use nix::time::{clock_gettime, ClockId};
 
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "freebsd"))]
 const CLOCK_ID: ClockId = ClockId::CLOCK_MONOTONIC;
-#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
+#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "freebsd")))]
 const CLOCK_ID: ClockId = ClockId::CLOCK_BOOTTIME;
 
 #[derive(Clone, Copy, Debug)]


### PR DESCRIPTION
Adds build support for FreeBSD.

Based on:

* https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=264993#c5
* https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=264993#c8