### PR TITLE
Adding clone to errors

### DIFF
--- a/boringtun/src/noise/errors.rs
+++ b/boringtun/src/noise/errors.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2019 Cloudflare, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum WireGuardError {
     DestinationBufferTooSmall,
     IncorrectPacketLength,


### PR DESCRIPTION
 A use case needed to make a copy of the errors object so I've made the errors object Cloneable.