### PR TITLE
fix: fix udp socket creation argument error

### DIFF
--- a/boringtun/src/device/peer.rs
+++ b/boringtun/src/device/peer.rs
@@ -117,7 +117,7 @@ impl Peer {
             .expect("Attempt to connect to undefined endpoint");
 
         let udp_conn =
-            socket2::Socket::new(Domain::for_address(addr), Type::STREAM, Some(Protocol::UDP))?;
+            socket2::Socket::new(Domain::for_address(addr), Type::DGRAM, Some(Protocol::UDP))?;
         udp_conn.set_reuse_address(true)?;
         let bind_addr = if addr.is_ipv4() {
             SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, port).into()


### PR DESCRIPTION
## background

in these https://github.com/cloudflare/boringtun/issues/352 https://github.com/cloudflare/boringtun/issues/102 issues, someone mentioned that the performance is pretty low at the master branch, i encountered the same situation at my desktop and vps, so i checked out the previous commits and located the root cause.

# root cause 

from commit https://github.com/cloudflare/boringtun/commit/5a49e83556c7b16454e23853902761cfcabed27b, the hand-written udp socket was changed to socket2. but in peer.rs, the udp socket's creation method's argument was wrong.  

## fix

Changed the socket type from `Type::STREAM` to `Type::DGRAM` to correctly handle UDP connections.

## tests 

i have tested several commits's performance with iperf3. after the fix, the throughput was finally ok