### PR TITLE
docs: add readme to crates

### DIFF
--- a/boringtun-cli/Cargo.toml
+++ b/boringtun-cli/Cargo.toml
@@ -4,6 +4,7 @@ description = "an implementation of the WireGuard® protocol designed for portab
 version = "0.6.0"
 authors = ["Noah Kennedy <nkennedy@cloudflare.com>", "Andy Grover <agrover@cloudflare.com>", "Jeff Hiner <jhiner@cloudflare.com>"]
 license = "BSD-3-Clause"
+readme = "../README.md"
 repository = "https://github.com/cloudflare/boringtun"
 documentation = "https://docs.rs/boringtun/0.5.2/boringtun/"
 edition = "2021"

--- a/boringtun/Cargo.toml
+++ b/boringtun/Cargo.toml
@@ -8,6 +8,7 @@ authors = [
     "Jeff Hiner <jhiner@cloudflare.com>",
 ]
 license = "BSD-3-Clause"
+readme = "../README.md"
 repository = "https://github.com/cloudflare/boringtun"
 documentation = "https://docs.rs/boringtun/0.5.2/boringtun/"
 edition = "2018"


### PR DESCRIPTION
I noticed when I found the `boringtun` and `boringtun-cli` crates on https://crates.io (https://crates.io/crates/boringtun) that there was no `readme` set for them. The landing page just says `boringtun v0.6.0 appears to have no README.md file`.

If you want, you can set the `readme` on these crates to the `README.md` file at the root of the cargo workspace, which is what this patch adds. 