### PR TITLE
Use 64-bit integer for session sending key counter on 32-bit platforms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,6 +93,7 @@ dependencies = [
  "mock_instant",
  "nix",
  "parking_lot",
+ "portable-atomic",
  "rand_core",
  "ring",
  "socket2",
@@ -783,6 +784,12 @@ dependencies = [
  "opaque-debug",
  "universal-hash",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "proc-macro2"

--- a/boringtun/Cargo.toml
+++ b/boringtun/Cargo.toml
@@ -27,6 +27,7 @@ hex = "0.4"
 untrusted = "0.9.0"
 libc = "0.2"
 parking_lot = "0.12"
+portable-atomic = { version = "1.13.1", features = ["fallback"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3", features = ["fmt"], optional = true }
 ip_network = "0.4.1"

--- a/boringtun/src/noise/rate_limiter.rs
+++ b/boringtun/src/noise/rate_limiter.rs
@@ -5,7 +5,7 @@ use crate::noise::{HandshakeInit, HandshakeResponse, Packet, Tunn, TunnResult, W
 #[cfg(feature = "mock-instant")]
 use mock_instant::Instant;
 use std::net::IpAddr;
-use std::sync::atomic::{AtomicU64, Ordering};
+use portable_atomic::{AtomicU64, Ordering};
 
 #[cfg(not(feature = "mock-instant"))]
 use crate::sleepyinstant::Instant;

--- a/boringtun/src/noise/session.rs
+++ b/boringtun/src/noise/session.rs
@@ -5,7 +5,7 @@ use super::PacketData;
 use crate::noise::errors::WireGuardError;
 use parking_lot::Mutex;
 use ring::aead::{Aad, LessSafeKey, Nonce, UnboundKey, CHACHA20_POLY1305};
-use std::sync::atomic::{AtomicU64, Ordering};
+use portable_atomic::{AtomicU64, Ordering};
 
 pub struct Session {
     pub(crate) receiving_index: u32,

--- a/boringtun/src/noise/session.rs
+++ b/boringtun/src/noise/session.rs
@@ -5,14 +5,14 @@ use super::PacketData;
 use crate::noise::errors::WireGuardError;
 use parking_lot::Mutex;
 use ring::aead::{Aad, LessSafeKey, Nonce, UnboundKey, CHACHA20_POLY1305};
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 pub struct Session {
     pub(crate) receiving_index: u32,
     sending_index: u32,
     receiver: LessSafeKey,
     sender: LessSafeKey,
-    sending_key_counter: AtomicUsize,
+    sending_key_counter: AtomicU64,
     receiving_key_counter: Mutex<ReceivingKeyCounterValidator>,
 }
 
@@ -165,7 +165,7 @@ impl Session {
                 UnboundKey::new(&CHACHA20_POLY1305, &receiving_key).unwrap(),
             ),
             sender: LessSafeKey::new(UnboundKey::new(&CHACHA20_POLY1305, &sending_key).unwrap()),
-            sending_key_counter: AtomicUsize::new(0),
+            sending_key_counter: AtomicU64::new(0),
             receiving_key_counter: Mutex::new(Default::default()),
         }
     }
@@ -198,7 +198,7 @@ impl Session {
             panic!("The destination buffer is too small");
         }
 
-        let sending_key_counter = self.sending_key_counter.fetch_add(1, Ordering::Relaxed) as u64;
+        let sending_key_counter = self.sending_key_counter.fetch_add(1, Ordering::Relaxed);
 
         let (message_type, rest) = dst.split_at_mut(4);
         let (receiver_index, rest) = rest.split_at_mut(4);


### PR DESCRIPTION
The sending key/nonce counter must be 64 bits wide, but the current implementation uses `AtomicUsize`, which is only 32 bits wide on 32-bit platforms. This will wrap-around after 2^32 packets are sent in a single _secure session_, hence leading to nonce reuse. This is less likely in practice, since secure sessions are expected to rotate every 120 seconds.

This change switches the counter to AtomicU64. However, AtomicU64 is not available on `arm-linux-androideabi` (but is on the other arm targets), so maintaining support for that target may require using `AtomicU64` from the `portable_atomic` crate or a `Mutex<u64>`