### PR TITLE
Change nonce counter type from AtomicUSize to AtomicU64

### DIFF
--- a/boringtun/src/noise/session.rs
+++ b/boringtun/src/noise/session.rs
@@ -5,14 +5,14 @@ use super::PacketData;
 use crate::noise::errors::WireGuardError;
 use parking_lot::Mutex;
 use ring::aead::{Aad, LessSafeKey, Nonce, UnboundKey, CHACHA20_POLY1305};
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 pub struct Session {
     pub(crate) receiving_index: u32,
     sending_index: u32,
     receiver: LessSafeKey,
     sender: LessSafeKey,
-    sending_key_counter: AtomicUsize,
+    sending_key_counter: AtomicU64,
     receiving_key_counter: Mutex<ReceivingKeyCounterValidator>,
 }
 
@@ -165,7 +165,7 @@ impl Session {
                 UnboundKey::new(&CHACHA20_POLY1305, &receiving_key).unwrap(),
             ),
             sender: LessSafeKey::new(UnboundKey::new(&CHACHA20_POLY1305, &sending_key).unwrap()),
-            sending_key_counter: AtomicUsize::new(0),
+            sending_key_counter: AtomicU64::new(0),
             receiving_key_counter: Mutex::new(Default::default()),
         }
     }


### PR DESCRIPTION
Change `sending_key_counter` nonce counter type from `AtomicUSize` to `AtomicU64` in `session.rs` to remove security dependency on value of rekey timer. This removes the risk of a nonce reuse attack on 32-bit platforms if the `REKEY_AFTER_TIME` = 120 seconds (in `timers.rs`) value is ever changed to a higher value by a user/developer (e.g., to improve performance on lower powered systems). Behaviour should otherwise be identical.

As discussed with Bas Westerbaan and Celeste Sinéad.