### PR TITLE
Use portable-atomic for 64 bit atomics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Security
+- use a 64-bit nonce counter on 32-bit platforms to avoid the possibility of nonce re-use with large REKEY_AFTER_TIME
+
+### Fixed
+- use portable-atomic to support targets without native 64-bit atomics
+
 ## [0.7.0] - 2026-01-09
 
 ### Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,7 @@ dependencies = [
  "mock_instant",
  "nix",
  "parking_lot",
+ "portable-atomic",
  "rand_core",
  "ring",
  "socket2",
@@ -822,6 +823,12 @@ dependencies = [
  "opaque-debug",
  "universal-hash",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "powerfmt"

--- a/boringtun/Cargo.toml
+++ b/boringtun/Cargo.toml
@@ -27,6 +27,7 @@ hex = "0.4"
 untrusted = "0.9.0"
 libc = "0.2"
 parking_lot = "0.12"
+portable-atomic = { version = "1.13.1", features = ["fallback"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3", features = ["fmt"], optional = true }
 ip_network = "0.4.1"

--- a/boringtun/src/noise/rate_limiter.rs
+++ b/boringtun/src/noise/rate_limiter.rs
@@ -4,8 +4,8 @@ use crate::noise::{HandshakeInit, HandshakeResponse, Packet, Tunn, TunnResult, W
 
 #[cfg(feature = "mock-instant")]
 use mock_instant::Instant;
+use portable_atomic::{AtomicU64, Ordering};
 use std::net::IpAddr;
-use std::sync::atomic::{AtomicU64, Ordering};
 
 #[cfg(not(feature = "mock-instant"))]
 use crate::sleepyinstant::Instant;

--- a/boringtun/src/noise/session.rs
+++ b/boringtun/src/noise/session.rs
@@ -4,8 +4,8 @@
 use super::PacketData;
 use crate::noise::errors::WireGuardError;
 use parking_lot::Mutex;
+use portable_atomic::{AtomicU64, Ordering};
 use ring::aead::{Aad, LessSafeKey, Nonce, UnboundKey, CHACHA20_POLY1305};
-use std::sync::atomic::{AtomicU64, Ordering};
 
 pub struct Session {
     pub(crate) receiving_index: u32,


### PR DESCRIPTION
This is #460 rebased on top of #468 plus associated changelog notes.

Note that the `arm-linux-androideabi` target we declare support for does not support 64 bit atomics and thus has been broken for quite some time (years) by the use of `std::sync::atomic::AtomicU64` ... which I've created #470 for 😐 