### PR TITLE
Use ip+port for calculating cookie

### DIFF
--- a/boringtun/src/device/mod.rs
+++ b/boringtun/src/device/mod.rs
@@ -28,7 +28,7 @@ pub mod tun;
 use std::collections::HashMap;
 use std::io::{self, Write as _};
 use std::mem::MaybeUninit;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 use std::os::unix::io::AsRawFd;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -610,7 +610,7 @@ impl Device {
                     let packet = &t.src_buf[..packet_len];
                     // The rate limiter initially checks mac1 and mac2, and optionally asks to send a cookie
                     let parsed_packet = match rate_limiter.verify_packet(
-                        Some(addr.as_socket().unwrap().ip()),
+                        Some(addr.as_socket().unwrap()),
                         packet,
                         &mut t.dst_buf,
                     ) {
@@ -677,11 +677,10 @@ impl Device {
 
                     // This packet was OK, that means we want to create a connected socket for this peer
                     let addr = addr.as_socket().unwrap();
-                    let ip_addr = addr.ip();
                     p.set_endpoint(addr);
                     if d.config.use_connected_socket {
                         if let Ok(sock) = p.connect_endpoint(d.listen_port, d.fwmark) {
-                            d.register_conn_handler(Arc::clone(peer), sock, ip_addr)
+                            d.register_conn_handler(Arc::clone(peer), sock, addr)
                                 .unwrap();
                         }
                     }
@@ -701,7 +700,7 @@ impl Device {
         &self,
         peer: Arc<Mutex<Peer>>,
         udp: socket2::Socket,
-        peer_addr: IpAddr,
+        peer_addr: SocketAddr,
     ) -> Result<(), Error> {
         self.queue.new_event(
             udp.as_raw_fd(),
@@ -720,7 +719,7 @@ impl Device {
                 while let Ok(read_bytes) = udp.recv(src_buf) {
                     let mut flush = false;
                     let mut p = peer.lock();
-                    match p.tunnel.decapsulate(
+                    match p.tunnel.decapsulate_from(
                         Some(peer_addr),
                         &t.src_buf[..read_bytes],
                         &mut t.dst_buf[..],

--- a/boringtun/src/noise/mod.rs
+++ b/boringtun/src/noise/mod.rs
@@ -16,7 +16,7 @@ use crate::x25519;
 
 use std::collections::VecDeque;
 use std::convert::{TryFrom, TryInto};
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -273,9 +273,24 @@ impl Tunn {
     /// If the result is of type TunnResult::WriteToNetwork, should repeat the call with empty datagram,
     /// until TunnResult::Done is returned. If batch processing packets, it is OK to defer until last
     /// packet is processed.
+    ///
+    /// If the source port is known, prefer [`Tunn::decapsulate_from`], which binds cookies
+    /// to the full source endpoint; this method stands in a fixed port of 0.
     pub fn decapsulate<'a>(
         &mut self,
         src_addr: Option<IpAddr>,
+        datagram: &[u8],
+        dst: &'a mut [u8],
+    ) -> TunnResult<'a> {
+        self.decapsulate_from(src_addr.map(|ip| SocketAddr::new(ip, 0)), datagram, dst)
+    }
+
+    /// Same as [`Tunn::decapsulate`], but takes the full source socket address so that,
+    /// under load, cookies are bound to the sender's IP and port (WireGuard whitepaper
+    /// section 5.4.7) rather than the IP alone.
+    pub fn decapsulate_from<'a>(
+        &mut self,
+        src_addr: Option<SocketAddr>,
         datagram: &[u8],
         dst: &'a mut [u8],
     ) -> TunnResult<'a> {
@@ -709,6 +724,91 @@ mod tests {
         let resp = create_handshake_response(&mut their_tun, &init);
         let packet = Tunn::parse_incoming_packet(&resp).unwrap();
         assert!(matches!(packet, Packet::HandshakeResponse(_)));
+    }
+
+    #[test]
+    fn under_load_cookie_is_bound_to_source_ip_and_port() {
+        let my_secret_key = x25519_dalek::StaticSecret::random_from_rng(OsRng);
+        let my_public_key = x25519_dalek::PublicKey::from(&my_secret_key);
+
+        let their_secret_key = x25519_dalek::StaticSecret::random_from_rng(OsRng);
+        let their_public_key = x25519_dalek::PublicKey::from(&their_secret_key);
+
+        // A rate limiter with a limit of 0 handshakes per second is always under load
+        let their_rate_limiter = Arc::new(RateLimiter::new(&their_public_key, 0));
+
+        let mut my_tun = Tunn::new(
+            my_secret_key,
+            their_public_key,
+            None,
+            None,
+            OsRng.next_u32(),
+            None,
+        );
+        let mut their_tun = Tunn::new(
+            their_secret_key,
+            my_public_key,
+            None,
+            None,
+            OsRng.next_u32(),
+            Some(their_rate_limiter),
+        );
+
+        let src = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)), 1234);
+        let same_ip_other_port = SocketAddr::new(src.ip(), 5678);
+
+        // Without a valid mac2, the loaded responder demands a cookie
+        let init = create_handshake_init(&mut my_tun);
+        let mut dst = vec![0u8; 2048];
+        let cookie_reply = match their_tun.decapsulate_from(Some(src), &init, &mut dst) {
+            TunnResult::WriteToNetwork(sent) => sent.to_vec(),
+            unexpected => panic!("expected a cookie reply, got {:?}", unexpected),
+        };
+        assert!(matches!(
+            Tunn::parse_incoming_packet(&cookie_reply).unwrap(),
+            Packet::PacketCookieReply(_)
+        ));
+
+        // The initiator stores the cookie and retries with mac2 set
+        let mut dst = vec![0u8; 2048];
+        assert!(matches!(
+            my_tun.decapsulate(None, &cookie_reply, &mut dst),
+            TunnResult::Done
+        ));
+        let mut dst = vec![0u8; 2048];
+        let init_with_mac2 = match my_tun.format_handshake_initiation(&mut dst, true) {
+            TunnResult::WriteToNetwork(sent) => sent.to_vec(),
+            unexpected => panic!("expected handshake initiation, got {:?}", unexpected),
+        };
+
+        // From the endpoint the cookie was issued to, the handshake proceeds
+        let mut dst = vec![0u8; 2048];
+        let resp = match their_tun.decapsulate_from(Some(src), &init_with_mac2, &mut dst) {
+            TunnResult::WriteToNetwork(sent) => sent.to_vec(),
+            unexpected => panic!("expected handshake response, got {:?}", unexpected),
+        };
+        assert!(matches!(
+            Tunn::parse_incoming_packet(&resp).unwrap(),
+            Packet::HandshakeResponse(_)
+        ));
+
+        // From the same IP but a different port, the stored cookie must not
+        // validate; the responder demands a new cookie instead of processing
+        // the handshake
+        let mut dst = vec![0u8; 2048];
+        let retry = match my_tun.format_handshake_initiation(&mut dst, true) {
+            TunnResult::WriteToNetwork(sent) => sent.to_vec(),
+            unexpected => panic!("expected handshake initiation, got {:?}", unexpected),
+        };
+        let mut dst = vec![0u8; 2048];
+        let reply = match their_tun.decapsulate_from(Some(same_ip_other_port), &retry, &mut dst) {
+            TunnResult::WriteToNetwork(sent) => sent.to_vec(),
+            unexpected => panic!("expected a cookie reply, got {:?}", unexpected),
+        };
+        assert!(matches!(
+            Tunn::parse_incoming_packet(&reply).unwrap(),
+            Packet::PacketCookieReply(_)
+        ));
     }
 
     #[test]

--- a/boringtun/src/noise/rate_limiter.rs
+++ b/boringtun/src/noise/rate_limiter.rs
@@ -5,7 +5,7 @@ use crate::noise::{HandshakeInit, HandshakeResponse, Packet, Tunn, TunnResult, W
 #[cfg(feature = "mock-instant")]
 use mock_instant::Instant;
 use portable_atomic::{AtomicU64, Ordering};
-use std::net::IpAddr;
+use std::net::{IpAddr, SocketAddr};
 
 #[cfg(not(feature = "mock-instant"))]
 use crate::sleepyinstant::Instant;
@@ -85,16 +85,18 @@ impl RateLimiter {
         }
     }
 
-    /// Compute the correct cookie value based on the current secret value and the source IP
-    fn current_cookie(&self, addr: IpAddr) -> Cookie {
-        let mut addr_bytes = [0u8; 16];
+    /// Compute the correct cookie value based on the current secret value and the source IP + port
+    fn current_cookie(&self, addr: SocketAddr) -> Cookie {
+        // 16 bytes for the IP address (max, IPv6) followed by 2 bytes for the UDP port
+        let mut addr_bytes = [0u8; 16 + 2];
 
-        match addr {
+        match addr.ip() {
             IpAddr::V4(a) => addr_bytes[..4].copy_from_slice(&a.octets()[..]),
-            IpAddr::V6(a) => addr_bytes[..].copy_from_slice(&a.octets()[..]),
+            IpAddr::V6(a) => addr_bytes[..16].copy_from_slice(&a.octets()[..]),
         }
+        addr_bytes[16..].copy_from_slice(&addr.port().to_le_bytes());
 
-        // The current cookie for a given IP is the MAC(responder.changing_secret_every_two_minutes, initiator.ip_address)
+        // The current cookie for a given endpoint is MAC(responder.changing_secret_every_two_minutes, initiator.ip_address || initiator.udp_port)
         // First we derive the secret from the current time, the value of cur_counter would change with time.
         let cur_counter = Instant::now().duration_since(self.start_time).as_secs() / COOKIE_REFRESH;
 
@@ -152,7 +154,7 @@ impl RateLimiter {
     /// Verify the MAC fields on the datagram, and apply rate limiting if needed
     pub fn verify_packet<'a, 'b>(
         &self,
-        src_addr: Option<IpAddr>,
+        src_addr: Option<SocketAddr>,
         src: &'a [u8],
         dst: &'b mut [u8],
     ) -> Result<Packet<'a>, TunnResult<'b>> {


### PR DESCRIPTION
BoringTun currently uses only the remote peer's IP address when computing the cookie for cookie reply messages, not IP+port. The WireGuard whitepaper is a bit unclear on this: section 5.4.7 explicitly defines the cookie as a MAC over "a concatenation of the external IP source address and UDP source port", while the informal description in section 5.3 mentions only the source IP. Upstream implementations include the port. 